### PR TITLE
Fix accessibility enumeration hang on SwiftUI containers

### DIFF
--- a/Sources/LoupeKit/LoupeAgent.swift
+++ b/Sources/LoupeKit/LoupeAgent.swift
@@ -622,9 +622,13 @@ public final class LoupeAgent {
         let directElements: [NSObject]
         if let elements = container.accessibilityElements, !elements.isEmpty {
             directElements = elements.compactMap { $0 as? NSObject }
+        } else if let synthesized = synthesizedAccessibilityElements(of: container) {
+            directElements = synthesized
         } else {
             let count = container.accessibilityElementCount()
-            guard count > 0 else {
+            // SwiftUI views such as CGDrawingView return NSNotFound here; (0..<NSNotFound)
+            // would iterate ~2^63 times and hang. Treat NSNotFound/non-positive as no elements.
+            guard count > 0, count != NSNotFound else {
                 return []
             }
             directElements = (0..<count).compactMap { container.accessibilityElement(at: $0) as? NSObject }
@@ -647,6 +651,19 @@ public final class LoupeAgent {
         }
 
         return elements
+    }
+
+    // `accessibilityElement(at:)` re-synthesizes the whole `_accessibilityElements`
+    // array on every call, making per-index enumeration O(N^2) and hanging large
+    // SwiftUI hosting containers. Read the synthesized array once to stay O(N).
+    private func synthesizedAccessibilityElements(of container: NSObject) -> [NSObject]? {
+        let selector = NSSelectorFromString("_accessibilityElements")
+        guard container.responds(to: selector),
+              let elements = container.perform(selector)?.takeUnretainedValue() as? [Any],
+              !elements.isEmpty else {
+            return nil
+        }
+        return elements.compactMap { $0 as? NSObject }
     }
 
     func makeRef() -> String {


### PR DESCRIPTION
## Summary

`nativeAccessibilityElements` could hang while capturing SwiftUI hosting containers:

- `accessibilityElementCount()` returns `NSNotFound` for some SwiftUI views (e.g. `CGDrawingView`), so `(0..<NSNotFound)` iterated ~2^63 times. Now guarded against `NSNotFound`/non-positive counts.
- `accessibilityElement(at:)` re-synthesizes the whole `_accessibilityElements` array on every call, making per-index enumeration O(N^2). Read the synthesized array once instead (O(N)).

Purely defensive hardening — no behavior change on runtimes that already enumerate correctly.

## Verification

- `swift test` ✅
- release CLI build ✅
- platform builds (macOS / iOS / tvOS cross-build) ✅
- macOS example E2E ✅
- iOS E2E: `run-injected.sh`, `run-runtime-e2e.sh`, `run-bookmark-e2e.sh` ✅
- `run-native-scenarios.sh` on iPhone 17 Pro Max / iOS 26.4 ✅ (12/12 cases, no timeouts). No regression vs baseline — that scenario is already green on iOS 26.4 with or without this change.

Full `scripts/verify-agent-work.sh` could not complete locally: no Apple TV / watchOS simulators installed, so the tvOS step exits 1. CI runs the full harness.

## Known issue (iOS 18.6, pre-existing — not fixed here)

On iPhone 12 Pro Max / iOS 18.6, `run-native-scenarios.sh` fails at the SwiftUI fixture case:

- **Without this change:** the request times out after 3s (the hang above).
- **With this change:** no hang, but the snapshot is missing the `example.fixtures.swiftui.controls`, `.rows`, and `.row.1` probe nodes, so the assertion still fails.

Those nodes come from `.localLoupeProbe(...)` background views and surface correctly on iOS 26.4 but not iOS 18.6 — an iOS-version-specific SwiftUI hosting behavior, separate from this change. Worth a follow-up.
