### PR TITLE
Backport Loupe to the Xcode 16.2 Swift 6 floor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/LoupeCLI/LoupeCLI.swift
+++ b/Sources/LoupeCLI/LoupeCLI.swift
@@ -1685,7 +1685,7 @@ struct LoupeCLI {
             diff: diffURL.path,
             targets: targetsURL.path,
             responses: responsesURL.path,
-            traceDirectory: options.traceDirectory.path,
+            traceDirectory: options.traceDirectory.path
         )
         let resultData = try encoder.encode(result)
         try resultData.write(to: options.traceDirectory.appendingPathComponent("summary.json"))

--- a/Sources/LoupeKit/LoupeAgentAppKit.swift
+++ b/Sources/LoupeKit/LoupeAgentAppKit.swift
@@ -1429,10 +1429,18 @@ private func runtimeConstraints() -> [NSLayoutConstraint] {
     }
 
     func visit(_ view: NSView) {
-        view.constraints.forEach(append)
-        view.constraintsAffectingLayout(for: .horizontal).forEach(append)
-        view.constraintsAffectingLayout(for: .vertical).forEach(append)
-        view.subviews.forEach(visit)
+        for constraint in view.constraints {
+            append(constraint)
+        }
+        for constraint in view.constraintsAffectingLayout(for: .horizontal) {
+            append(constraint)
+        }
+        for constraint in view.constraintsAffectingLayout(for: .vertical) {
+            append(constraint)
+        }
+        for subview in view.subviews {
+            visit(subview)
+        }
     }
 
     for window in NSApp.windows {

--- a/Sources/LoupeKit/LoupeAgentMutations.swift
+++ b/Sources/LoupeKit/LoupeAgentMutations.swift
@@ -796,10 +796,18 @@ private func runtimeConstraints() -> [NSLayoutConstraint] {
     }
 
     func visit(_ view: UIView) {
-        view.constraints.forEach(append)
-        view.constraintsAffectingLayout(for: .horizontal).forEach(append)
-        view.constraintsAffectingLayout(for: .vertical).forEach(append)
-        view.subviews.forEach(visit)
+        for constraint in view.constraints {
+            append(constraint)
+        }
+        for constraint in view.constraintsAffectingLayout(for: .horizontal) {
+            append(constraint)
+        }
+        for constraint in view.constraintsAffectingLayout(for: .vertical) {
+            append(constraint)
+        }
+        for subview in view.subviews {
+            visit(subview)
+        }
     }
 
     for scene in UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }) {

--- a/Sources/LoupeKit/LoupeAgentSyntheticItems.swift
+++ b/Sources/LoupeKit/LoupeAgentSyntheticItems.swift
@@ -304,10 +304,14 @@ func barButtonCandidateViews(in view: UIView) -> [UIView] {
         if current is UIControl {
             result.append(current)
         }
-        current.subviews.forEach(walk)
+        for subview in current.subviews {
+            walk(subview)
+        }
     }
 
-    view.subviews.forEach(walk)
+    for subview in view.subviews {
+        walk(subview)
+    }
     return result.sorted { lhs, rhs in
         barButtonCandidateArea(lhs) > barButtonCandidateArea(rhs)
     }
@@ -370,10 +374,14 @@ func tabBarItemCandidateViews(in view: UIView) -> [UIView] {
         if current is UIControl {
             result.append(current)
         }
-        current.subviews.forEach(walk)
+        for subview in current.subviews {
+            walk(subview)
+        }
     }
 
-    view.subviews.forEach(walk)
+    for subview in view.subviews {
+        walk(subview)
+    }
     return result.sorted {
         let lhsFrame = frameInScreen(for: $0)
         let rhsFrame = frameInScreen(for: $1)
@@ -400,7 +408,9 @@ func descendantText(in view: UIView) -> String {
         if let label = current.accessibilityLabel, !label.isEmpty {
             parts.append(label)
         }
-        current.subviews.forEach(walk)
+        for subview in current.subviews {
+            walk(subview)
+        }
     }
 
     walk(view)


### PR DESCRIPTION
Retain Swift tools 6.0 after the 5.10 probe showed tests depend on Swift Testing, while keeping minor syntax cleanups that are compatible with Swift 6 builds.

Constraint: Existing test suite uses Swift Testing and is verified with Xcode 16.2 / Swift 6.0.3.

Rejected: Lowering to Swift 5.10 | pure Xcode 15.4 test runs fail because Swift Testing is unavailable.

Confidence: high

Scope-risk: narrow

Directive: Do not lower the package tools version below Swift 6 without also migrating the test suite away from Swift Testing or adding an equivalent compatible test path.

Tested: DEVELOPER_DIR=/Applications/Xcode-16.2.0.app/Contents/Developer xcrun swift --version; swift package describe reports tools_version=6.0; git diff --check --cached; DEVELOPER_DIR=/Applications/Xcode-16.2.0.app/Contents/Developer scripts/verify-agent-work.sh passed swift test, release CLI build, platform build verification, and macOS example E2E.

Not-tested: tvOS example E2E could not run locally because no Apple TV simulator is available.