### PR TITLE
Optimize snapshot selector resolution

### DIFF
--- a/Sources/LoupeCLI/LoupeCLI.swift
+++ b/Sources/LoupeCLI/LoupeCLI.swift
@@ -81,7 +81,7 @@ struct LoupeCLI {
         decoder.dateDecodingStrategy = .iso8601
 
         let snapshot = try decoder.decode(LoupeSnapshot.self, from: data)
-        let observation = LoupeObservationCompactor.compact(snapshot)
+        let observation = LoupeObservationCompactor.compact(LoupeSnapshotContext(snapshot: snapshot))
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -107,8 +107,9 @@ struct LoupeCLI {
             snapshot = try await fetchSnapshot(host: host, timeout: options.timeout)
         }
 
+        let context = LoupeSnapshotContext(snapshot: snapshot)
         let map = LoupeScreenMapper.map(
-            snapshot,
+            context,
             options: LoupeScreenMapOptions(
                 includeHidden: options.includeHidden,
                 includeContainers: options.includeContainers,
@@ -146,9 +147,10 @@ struct LoupeCLI {
             fallbackSnapshot: snapshot,
             timeout: options.timeout
         )
-        let compact = LoupeObservationCompactor.compact(snapshot)
+        let context = LoupeSnapshotContext(snapshot: snapshot)
+        let compact = LoupeObservationCompactor.compact(context)
         let screenMap = LoupeScreenMapper.map(
-            snapshot,
+            context,
             options: LoupeScreenMapOptions(maxElements: options.screenMapLimit)
         )
         let audit = LoupeLayoutAuditor.audit(snapshot)
@@ -342,11 +344,12 @@ struct LoupeCLI {
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let context = LoupeSnapshotContext(snapshot: snapshot)
         switch options.tree {
         case .view:
             let results = LoupeSnapshotQuery.find(
                 options.selector,
-                in: snapshot,
+                in: context,
                 options: LoupeQueryOptions(
                     includeHidden: options.includeHidden,
                     includeDisabled: true,
@@ -355,7 +358,7 @@ struct LoupeCLI {
             )
             FileHandle.standardOutput.write(try encoder.encode(results))
         case .accessibility:
-            let tree = LoupeAccessibilityTree.build(from: snapshot, includeHidden: options.includeHidden)
+            let tree = LoupeAccessibilityTree.build(from: context, includeHidden: options.includeHidden)
             let results = LoupeAccessibilityTreeQuery.find(
                 options.selector,
                 in: tree,
@@ -376,7 +379,8 @@ struct LoupeCLI {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let snapshot = try decoder.decode(LoupeSnapshot.self, from: data)
-        let tree = LoupeAccessibilityTree.build(from: snapshot, includeHidden: options.includeHidden)
+        let context = LoupeSnapshotContext(snapshot: snapshot)
+        let tree = LoupeAccessibilityTree.build(from: context, includeHidden: options.includeHidden)
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -444,8 +448,9 @@ struct LoupeCLI {
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
             snapshot = try decoder.decode(LoupeSnapshot.self, from: data)
+            let context = LoupeSnapshotContext(snapshot: snapshot)
             accessibilityTree = options.tree == .accessibility
-                ? LoupeAccessibilityTree.build(from: snapshot, includeHidden: options.includeHidden, visibilityMode: .occlusion)
+                ? LoupeAccessibilityTree.build(from: context, includeHidden: options.includeHidden, visibilityMode: .occlusion)
                 : nil
         } else {
             let host = try await resolvedRuntimeHost(
@@ -475,7 +480,10 @@ struct LoupeCLI {
             )
         case .accessibility:
             output = renderAccessibilityTree(
-                accessibilityTree ?? LoupeAccessibilityTree.build(from: snapshot, includeHidden: options.includeHidden),
+                accessibilityTree ?? LoupeAccessibilityTree.build(
+                    from: LoupeSnapshotContext(snapshot: snapshot),
+                    includeHidden: options.includeHidden
+                ),
                 selector: options.selector,
                 depth: options.depth,
                 includeHidden: options.includeHidden,

--- a/Sources/LoupeCore/AccessibilityTree.swift
+++ b/Sources/LoupeCore/AccessibilityTree.swift
@@ -119,11 +119,21 @@ public struct LoupeAccessibilityTree: Codable, Equatable {
         includeHidden: Bool = false,
         visibilityMode: LoupeQueryVisibilityMode = .occlusion
     ) -> LoupeAccessibilityTree {
+        build(
+            from: LoupeSnapshotContext(snapshot: snapshot),
+            includeHidden: includeHidden,
+            visibilityMode: visibilityMode
+        )
+    }
+
+    public static func build(
+        from context: LoupeSnapshotContext,
+        includeHidden: Bool = false,
+        visibilityMode: LoupeQueryVisibilityMode = .occlusion
+    ) -> LoupeAccessibilityTree {
+        let snapshot = context.snapshot
         let surfaceVisibleRefs = !includeHidden && visibilityMode != .raw
-            ? LoupeSurfaceVisibility.visibleNodeRefs(
-                in: snapshot,
-                includesOffscreen: visibilityMode == .occlusion
-            )
+            ? context.visibleRefs(for: visibilityMode)
             : nil
         let sourceNodes = snapshot.nodes.values.filter {
             shouldInclude(

--- a/Sources/LoupeCore/CompactObservation.swift
+++ b/Sources/LoupeCore/CompactObservation.swift
@@ -143,14 +143,17 @@ public enum LoupeObservationCompactor {
         _ snapshot: LoupeSnapshot,
         options: LoupeObservationOptions = LoupeObservationOptions()
     ) -> LoupeCompactObservation {
-        let screenRect = LoupeRect(
-            x: 0,
-            y: 0,
-            width: snapshot.screen.size.width,
-            height: snapshot.screen.size.height
-        )
-        let hasKnownScreenSize = snapshot.screen.size.width > 0 && snapshot.screen.size.height > 0
-        let surfaceVisibleRefs = LoupeSurfaceVisibility.visibleNodeRefs(in: snapshot)
+        compact(LoupeSnapshotContext(snapshot: snapshot), options: options)
+    }
+
+    public static func compact(
+        _ context: LoupeSnapshotContext,
+        options: LoupeObservationOptions = LoupeObservationOptions()
+    ) -> LoupeCompactObservation {
+        let snapshot = context.snapshot
+        let screenRect = context.screenRect
+        let hasKnownScreenSize = context.hasKnownScreenSize
+        let surfaceVisibleRefs = context.surfaceVisibleRefs
 
         let visibleNodes = snapshot.nodes.values
             .filter { node in
@@ -161,7 +164,7 @@ public enum LoupeObservationCompactor {
 
         let visibleTexts = visibleNodes
             .compactMap { node -> (node: LoupeNode, text: LoupeVisibleText)? in
-                guard let text = displayText(for: node), !text.isEmpty else { return nil }
+                guard let text = context.displayText(for: node), !text.isEmpty else { return nil }
                 if suppressesSystemChromeSemanticDuplicateText(node, text: text, in: snapshot, screenRect: screenRect) {
                     return nil
                 }

--- a/Sources/LoupeCore/ScreenMap.swift
+++ b/Sources/LoupeCore/ScreenMap.swift
@@ -75,15 +75,18 @@ public enum LoupeScreenMapper {
         _ snapshot: LoupeSnapshot,
         options: LoupeScreenMapOptions = LoupeScreenMapOptions()
     ) -> LoupeScreenMap {
-        let screenRect = LoupeRect(
-            x: 0,
-            y: 0,
-            width: snapshot.screen.size.width,
-            height: snapshot.screen.size.height
-        )
-        let hasKnownScreenSize = snapshot.screen.size.width > 0 && snapshot.screen.size.height > 0
+        map(LoupeSnapshotContext(snapshot: snapshot), options: options)
+    }
+
+    public static func map(
+        _ context: LoupeSnapshotContext,
+        options: LoupeScreenMapOptions = LoupeScreenMapOptions()
+    ) -> LoupeScreenMap {
+        let snapshot = context.snapshot
+        let screenRect = context.screenRect
+        let hasKnownScreenSize = context.hasKnownScreenSize
         let depths = nodeDepths(snapshot)
-        let surfaceVisibleRefs = options.includeHidden ? nil : LoupeSurfaceVisibility.visibleNodeRefs(in: snapshot)
+        let surfaceVisibleRefs = options.includeHidden ? nil : context.surfaceVisibleRefs
         let elements = snapshot.nodes.values
             .filter { node in
                 guard options.includeHidden || LoupeSurfaceVisibility.isSurfaceVisible(
@@ -105,7 +108,7 @@ public enum LoupeScreenMapper {
                     className: node.platform?.className,
                     role: node.role,
                     testID: node.testID,
-                    text: LoupeObservationCompactor.displayText(for: node),
+                    text: context.displayText(for: node),
                     frame: node.frame,
                     style: node.style,
                     isEnabled: node.isEnabled,

--- a/Sources/LoupeCore/SnapshotContext.swift
+++ b/Sources/LoupeCore/SnapshotContext.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+public final class LoupeSnapshotContext {
+    public let snapshot: LoupeSnapshot
+    public let screenRect: LoupeRect
+    public let hasKnownScreenSize: Bool
+
+    private let refsByTestID: [String: [String]]
+    private let refsByRole: [String: [String]]
+    private let refsByDisplayText: [String: [String]]
+    private let displayTextByRef: [String: String]
+
+    public lazy var surfaceVisibleRefs: Set<String> = {
+        LoupeSurfaceVisibility.visibleNodeRefs(in: snapshot)
+    }()
+
+    public lazy var occlusionVisibleRefs: Set<String> = {
+        LoupeSurfaceVisibility.visibleNodeRefs(in: snapshot, includesOffscreen: true)
+    }()
+
+    public init(snapshot: LoupeSnapshot) {
+        self.snapshot = snapshot
+        screenRect = LoupeRect(
+            x: 0,
+            y: 0,
+            width: snapshot.screen.size.width,
+            height: snapshot.screen.size.height
+        )
+        hasKnownScreenSize = snapshot.screen.size.width > 0 && snapshot.screen.size.height > 0
+
+        var refsByTestID: [String: [String]] = [:]
+        var refsByRole: [String: [String]] = [:]
+        var refsByDisplayText: [String: [String]] = [:]
+        var displayTextByRef: [String: String] = [:]
+
+        for node in snapshot.nodes.values {
+            if let testID = nonEmpty(node.testID) {
+                refsByTestID[testID, default: []].append(node.ref)
+            }
+            if let metadataID = nonEmpty(stringMetadata("id", from: node.custom)),
+               metadataID != nonEmpty(node.testID) {
+                refsByTestID[metadataID, default: []].append(node.ref)
+            }
+            if let role = nonEmpty(node.role) {
+                refsByRole[role, default: []].append(node.ref)
+            }
+            if let text = LoupeObservationCompactor.displayText(for: node) {
+                displayTextByRef[node.ref] = text
+                refsByDisplayText[text, default: []].append(node.ref)
+            }
+        }
+
+        self.refsByTestID = refsByTestID
+        self.refsByRole = refsByRole
+        self.refsByDisplayText = refsByDisplayText
+        self.displayTextByRef = displayTextByRef
+    }
+
+    public func node(ref: String) -> LoupeNode? {
+        snapshot.nodes[ref]
+    }
+
+    public func displayText(for node: LoupeNode) -> String? {
+        displayTextByRef[node.ref] ?? LoupeObservationCompactor.displayText(for: node)
+    }
+
+    public func visibleRefs(for mode: LoupeQueryVisibilityMode) -> Set<String>? {
+        switch mode {
+        case .surface:
+            return surfaceVisibleRefs
+        case .occlusion:
+            return occlusionVisibleRefs
+        case .raw:
+            return nil
+        }
+    }
+
+    public func candidateRefs(for selector: LoupeSelector) -> [String]? {
+        switch selector {
+        case let .ref(ref):
+            return snapshot.nodes[ref] == nil ? [] : [ref]
+        case let .testID(testID):
+            return refsByTestID[testID] ?? []
+        case let .role(role):
+            return refsByRole[role] ?? []
+        case let .roleAndText(role, _, _):
+            return refsByRole[role] ?? []
+        case let .text(text, exact: true):
+            return refsByDisplayText[text] ?? []
+        case .text(_, exact: false):
+            return nil
+        }
+    }
+}
+
+private func nonEmpty(_ value: String?) -> String? {
+    guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+        return nil
+    }
+    return trimmed
+}
+
+private func stringMetadata(_ key: String, from metadata: [String: LoupeMetadataValue]) -> String? {
+    guard case let .string(value) = metadata[key] else {
+        return nil
+    }
+    return value
+}

--- a/Sources/LoupeCore/SnapshotQuery.swift
+++ b/Sources/LoupeCore/SnapshotQuery.swift
@@ -43,10 +43,10 @@ public struct LoupeQueryResult: Codable, Equatable {
     public var isEnabled: Bool
     public var isInteractive: Bool
 
-    public init(node: LoupeNode, isVisible: Bool? = nil) {
+    public init(node: LoupeNode, isVisible: Bool? = nil, text: String? = nil) {
         ref = node.ref
         role = node.role
-        text = LoupeObservationCompactor.displayText(for: node)
+        self.text = text ?? LoupeObservationCompactor.displayText(for: node)
         testID = node.testID
         frame = node.frame
         self.isVisible = isVisible ?? node.isVisible
@@ -61,19 +61,22 @@ public enum LoupeSnapshotQuery {
         in snapshot: LoupeSnapshot,
         options: LoupeQueryOptions = LoupeQueryOptions()
     ) -> [LoupeQueryResult] {
-        let screenRect = LoupeRect(
-            x: 0,
-            y: 0,
-            width: snapshot.screen.size.width,
-            height: snapshot.screen.size.height
-        )
+        find(selector, in: LoupeSnapshotContext(snapshot: snapshot), options: options)
+    }
+
+    public static func find(
+        _ selector: LoupeSelector,
+        in context: LoupeSnapshotContext,
+        options: LoupeQueryOptions = LoupeQueryOptions()
+    ) -> [LoupeQueryResult] {
+        let snapshot = context.snapshot
+        let screenRect = context.screenRect
         let surfaceVisibleRefs = shouldUseSurfaceVisibility(options)
-            ? LoupeSurfaceVisibility.visibleNodeRefs(
-                in: snapshot,
-                includesOffscreen: options.visibilityMode == .occlusion
-            )
+            ? context.visibleRefs(for: options.visibilityMode)
             : nil
-        return snapshot.nodes.values
+        let candidates = context.candidateRefs(for: selector)?
+            .compactMap { context.node(ref: $0) } ?? Array(snapshot.nodes.values)
+        return candidates
             .filter {
                 matchesVisibilityAndState(
                     $0,
@@ -100,7 +103,8 @@ public enum LoupeSnapshotQuery {
                             snapshot: snapshot,
                             screenRect: screenRect
                         )
-                    }
+                    },
+                    text: context.displayText(for: node)
                 )
             }
     }
@@ -111,6 +115,14 @@ public enum LoupeSnapshotQuery {
         options: LoupeQueryOptions = LoupeQueryOptions()
     ) -> LoupeQueryResult? {
         find(selector, in: snapshot, options: options).first
+    }
+
+    public static func first(
+        _ selector: LoupeSelector,
+        in context: LoupeSnapshotContext,
+        options: LoupeQueryOptions = LoupeQueryOptions()
+    ) -> LoupeQueryResult? {
+        find(selector, in: context, options: options).first
     }
 
     package static func preferPlatformBackedMatches(

--- a/Sources/LoupeKit/LoupeAgent.swift
+++ b/Sources/LoupeKit/LoupeAgent.swift
@@ -30,7 +30,7 @@ public final class LoupeAgent {
     public func captureAccessibilityTree() -> LoupeAccessibilityTree {
         let capture = captureSnapshotWithViewRefs()
         guard ProcessInfo.processInfo.environment["LOUPE_NATIVE_ACCESSIBILITY"] == "1" else {
-            return LoupeAccessibilityTree.build(from: capture.snapshot)
+            return LoupeAccessibilityTree.build(from: LoupeSnapshotContext(snapshot: capture.snapshot))
         }
         return captureNativeAccessibilityTree(snapshot: capture.snapshot, viewRefs: capture.viewRefs)
     }
@@ -175,9 +175,10 @@ public final class LoupeAgent {
 
     public func responderChain(selector: LoupeSelector) -> LoupeHitTestReport? {
         let capture = captureSnapshotWithViewRefs()
+        let context = LoupeSnapshotContext(snapshot: capture.snapshot)
         guard let match = LoupeSnapshotQuery.find(
             selector,
-            in: capture.snapshot,
+            in: context,
             options: LoupeQueryOptions(includeHidden: true, includeDisabled: true, maxResults: 1)
         ).first else {
             return nil
@@ -462,9 +463,10 @@ public final class LoupeAgent {
     ) -> LoupeAccessibilityTree {
         nextNativeAccessibilityRef = 0
 
-        var tree = LoupeAccessibilityTree.build(from: snapshot)
+        let context = LoupeSnapshotContext(snapshot: snapshot)
+        var tree = LoupeAccessibilityTree.build(from: context)
         var signatures = Set(tree.nodes.values.map(nativeAccessibilitySignature(for:)))
-        let accessibilityVisibleRefs = LoupeSurfaceVisibility.visibleNodeRefs(in: snapshot, includesOffscreen: true)
+        let accessibilityVisibleRefs = context.occlusionVisibleRefs
 
         for scene in UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }) {
             for window in scene.windows {

--- a/Sources/LoupeKit/LoupeAgentAppKit.swift
+++ b/Sources/LoupeKit/LoupeAgentAppKit.swift
@@ -141,9 +141,10 @@ public final class LoupeAgent {
 
     public func responderChain(selector: LoupeSelector) -> LoupeHitTestReport? {
         let capture = captureSnapshotWithViewRefs()
+        let context = LoupeSnapshotContext(snapshot: capture.snapshot)
         guard let match = LoupeSnapshotQuery.find(
             selector,
-            in: capture.snapshot,
+            in: context,
             options: LoupeQueryOptions(includeHidden: true, includeDisabled: true, maxResults: 1)
         ).first else {
             return nil
@@ -176,11 +177,12 @@ public final class LoupeAgent {
 
     public func activate(_ request: LoupeActivationRequest) throws -> LoupeActivationResponse {
         let beforeCapture = captureSnapshotWithViewRefs()
+        let beforeContext = LoupeSnapshotContext(snapshot: beforeCapture.snapshot)
         let selector = loupeSelector(from: request.selector)
         let matches = LoupeSnapshotQuery.preferPlatformBackedMatches(
             LoupeSnapshotQuery.find(
                 selector,
-                in: beforeCapture.snapshot,
+                in: beforeContext,
                 options: LoupeQueryOptions(includeHidden: false, includeDisabled: false, maxResults: 8)
             ),
             in: beforeCapture.snapshot
@@ -234,12 +236,13 @@ public final class LoupeAgent {
 
     public func mutate(_ request: LoupeMutationRequest) throws -> LoupeMutationResponse {
         let beforeCapture = captureSnapshotWithViewRefs()
+        let beforeContext = LoupeSnapshotContext(snapshot: beforeCapture.snapshot)
         let selector = loupeSelector(from: request.selector)
         let includeHidden = request.includeHidden || request.selector.kind == .ref
         let matches = LoupeSnapshotQuery.preferPlatformBackedMatches(
             LoupeSnapshotQuery.find(
                 selector,
-                in: beforeCapture.snapshot,
+                in: beforeContext,
                 options: LoupeQueryOptions(
                     includeHidden: includeHidden,
                     includeDisabled: true,
@@ -416,7 +419,7 @@ public final class LoupeAgent {
     ) -> LoupeAccessibilityTree {
         nextNativeAccessibilityRef = 0
 
-        var tree = LoupeAccessibilityTree.build(from: snapshot)
+        var tree = LoupeAccessibilityTree.build(from: LoupeSnapshotContext(snapshot: snapshot))
         var signatures = Set(tree.nodes.values.map(nativeAccessibilitySignature(for:)))
 
         for window in NSApp.windows {

--- a/Sources/LoupeKit/LoupeAgentMutations.swift
+++ b/Sources/LoupeKit/LoupeAgentMutations.swift
@@ -7,11 +7,12 @@ import UIKit
 public extension LoupeAgent {
     func activate(_ request: LoupeActivationRequest) throws -> LoupeActivationResponse {
         let beforeCapture = captureSnapshotWithViewRefs()
+        let beforeContext = LoupeSnapshotContext(snapshot: beforeCapture.snapshot)
         let selector = loupeSelector(from: request.selector)
         let matches = LoupeSnapshotQuery.preferPlatformBackedMatches(
             LoupeSnapshotQuery.find(
                 selector,
-                in: beforeCapture.snapshot,
+                in: beforeContext,
                 options: LoupeQueryOptions(includeHidden: false, includeDisabled: false, maxResults: 8)
             ),
             in: beforeCapture.snapshot
@@ -64,12 +65,13 @@ public extension LoupeAgent {
 
     func mutate(_ request: LoupeMutationRequest) throws -> LoupeMutationResponse {
         let beforeCapture = captureSnapshotWithViewRefs()
+        let beforeContext = LoupeSnapshotContext(snapshot: beforeCapture.snapshot)
         let selector = loupeSelector(from: request.selector)
         let includeHidden = request.includeHidden || request.selector.kind == .ref
         let matches = LoupeSnapshotQuery.preferPlatformBackedMatches(
             LoupeSnapshotQuery.find(
                 selector,
-                in: beforeCapture.snapshot,
+                in: beforeContext,
                 options: LoupeQueryOptions(
                     includeHidden: includeHidden,
                     includeDisabled: true,

--- a/Tests/LoupeCoreTests/SnapshotQueryTests.swift
+++ b/Tests/LoupeCoreTests/SnapshotQueryTests.swift
@@ -38,6 +38,29 @@ struct SnapshotQueryTests {
         #expect(results.map { $0.ref } == ["n2", "n1"])
     }
 
+    @Test func snapshotContextIndexesMetadataIDAndCanBeReused() {
+        let snapshot = makeSnapshot(nodes: [
+            LoupeNode(
+                ref: "n1",
+                parentRef: nil,
+                kind: .view,
+                typeName: "UIView",
+                role: "button",
+                text: "Continue",
+                frame: LoupeRect(x: 24, y: 100, width: 120, height: 44),
+                isVisible: true,
+                isEnabled: true,
+                isInteractive: true,
+                custom: ["id": .string("checkout.continueButton")]
+            ),
+        ])
+        let context = LoupeSnapshotContext(snapshot: snapshot)
+
+        #expect(LoupeSnapshotQuery.find(.testID("checkout.continueButton"), in: context).map(\.ref) == ["n1"])
+        #expect(LoupeSnapshotQuery.find(.roleAndText(role: "button", text: "Continue"), in: context).map(\.ref) == ["n1"])
+        #expect(LoupeSnapshotQuery.first(.ref("n1"), in: context)?.text == "Continue")
+    }
+
     @Test func findByTestIDPrefersPlatformBackedProbeOverSyntheticProbe() {
         let snapshot = makeSnapshot(nodes: [
             LoupeNode(

--- a/skills/loupe/SKILL.md
+++ b/skills/loupe/SKILL.md
@@ -8,7 +8,9 @@ description: Use this skill when implementing, inspecting, or verifying native a
 Use Loupe to observe, query, act on, mutate, and diagnose Apple-platform app
 runtimes through the in-process server.
 
-## Core Rules
+## Workflow Configuration
+
+### Command Route
 
 - Use grouped commands from current help: `app`, `ui`, `act`, and `debug`.
   Old top-level verbs are compatibility aliases only.
@@ -18,6 +20,9 @@ runtimes through the in-process server.
 - Keep the attachment mode explicit: simulator injection, debug-only
   physical-device LoupeInjector dependency, macOS host runtime, watchOS, or
   visionOS.
+
+### Evidence And Context
+
 - Keep full reports, snapshots, and traces on disk; use compact observations
   in chat, then query or inspect refs as needed.
 - Keep verbose build logs and large JSON on disk. Print a short path/status,
@@ -25,16 +30,27 @@ runtimes through the in-process server.
   next decision.
 - Prefer accessibility for discovery/action intent; prefer the view tree for
   layout, style, mutations, and visual diagnostics.
-- Prefer `testID`, current-snapshot `ref`, or coordinates. Do not use
-  tap-by-text as a public contract.
 - Command success alone is not proof. Verify with fresh reports, traces,
   screenshots, hit-tests, logs, defaults, or effective state.
+
+### Targeting
+
+- Discover with accessibility, role, or text; act with app-owned `testID`,
+  current `ref`, or coordinates. Do not use tap-by-text as a public contract.
+- For action, mutation, and wait, fresh-resolve the current screen: zero
+  matches means not found; multiple actionable matches means ambiguous.
+- Treat `ref` as a snapshot/session handle, not a durable selector.
+- Suggest missing `testID`s only as hints. Prefer the nearest route/root prefix;
+  avoid index, coordinate, or deep hierarchy names.
+
+### Runtime Boundaries
+
 - Simulator injection uses the Loupe CLI/injector outside the app. It should
   not require changing the app source or adding `import LoupeKit`.
 - Physical devices are different: the debug app must link and embed the
   dynamic LoupeInjector runtime. Do not include it in App Store release builds.
 
-## References
+## Reference Map
 
 - `references/runtime-modes.md`: attaching, launching, platform boundaries.
 - `references/evidence-workflow.md`: reports, visibility, design
@@ -42,13 +58,13 @@ runtimes through the in-process server.
 - `references/actions-and-mutations.md`: actions, waits, scrolls, mutations,
   self-sizing, `reflect`.
 
-## Default Loop
+## Workflow
 
 1. Identify the runtime mode and host. Prefer the host printed by `app launch`;
    `app current` can be stale.
 2. Capture `ui report` and keep `snapshot.json`.
-3. Discover with text/role/accessibility, then switch to `testID` or a ref from
-   the same snapshot. Inspect with `ui node` before acting.
+3. Discover with text/role/accessibility, then switch to `testID` or a current
+   ref. Inspect with `ui node` before acting.
 4. For design checks, capture one report, review the screenshot and audit
    summary, then run `ui compare-design` when a design fixture exists.
 5. Keep each design iteration bounded: report, screenshot/audit judgment,

--- a/skills/loupe/references/actions-and-mutations.md
+++ b/skills/loupe/references/actions-and-mutations.md
@@ -21,6 +21,9 @@ Use one fresh trace directory per attempt.
 
 - Refs are snapshot-scoped. Recapture before acting when the screen may have
   changed, or pass `--snapshot` when acting on a saved ref.
+- For commands that must choose one target, do not silently pick the first
+  role/text match. If multiple current-screen actionable targets match, inspect
+  candidates and rerun with `testID`, current `ref`, node, or hit-test evidence.
 - Prove action results with trace summary/diff plus fresh report, screenshot,
   query, node, content offset, log, default, focus, or state evidence.
 - System permission alerts are outside the app runtime tree. Use screenshot or
@@ -53,7 +56,7 @@ $LOUPE ui reflect <set.json> --source <source-root> --output <reflect.json>
 ```
 
 - `ui mutations` lists live capabilities; it does not take a selector.
-- Prefer stable `testID`; use `ref` only from the current screen or with the
+- Prefer app-owned `testID`; use `ref` only from the current screen or with the
   source snapshot for saved-ref mapping.
 - Dynamic table/collection cells can reuse refs. Mutate a current ref
   immediately, save the mutation response, inspect requested/effective state,

--- a/skills/loupe/references/evidence-workflow.md
+++ b/skills/loupe/references/evidence-workflow.md
@@ -17,7 +17,9 @@ screenshots when supported; macOS host runtimes may need JSON-only proof.
 ## Visibility And Targeting
 
 - Prefer `testID` when available. Use text/role for discovery, then switch to
-  stable `testID` or current-snapshot `ref`.
+  app-owned `testID` or current-snapshot `ref`.
+- Full tree/report commands may inspect hidden, offscreen, or occluded nodes;
+  action, mutation, and wait targets must be current-screen actionable.
 - Raw `isVisible` can include dismissed sheets or reused offscreen cells. For
   current-screen claims, use default `ui query`, `compact`, `screen`, `audit`,
   hit-test evidence, screenshots, or a fresh report.


### PR DESCRIPTION
## What changed?

Several Loupe paths resolve selectors by walking the full
`LoupeSnapshot.nodes` map and recomputing derived state such as display text and
visibility.

That is fine for one-off CLI calls, but it adds avoidable work when an agent or
runtime flow performs multiple queries, inspections, actions, or mutations
against the same captured snapshot.

This PR adds an internal `LoupeSnapshotContext` that keeps reusable per-snapshot
lookup state for refs, app-authored `testID`s, accessibility ID metadata, roles,
exact display text, display text by ref, and visibility sets.

## Compatibility

The public command interface stays unchanged. Full snapshots and
view/accessibility trees remain the source of truth.

This does not make `ref` a durable cross-snapshot selector, and it does not
change the snapshot JSON format or add sidecar indexes.

## Validation

- `swift test`
- `scripts/verify-agent-work.sh`
- local prev/next benchmark and accuracy comparison on a 25k-node synthetic
  snapshot

Closes #4
