### PR TITLE
Fix SwiftUI fixture probes on iOS 18.6

### DIFF
--- a/Examples/LoupeExample/LoupeExample/ViewController.swift
+++ b/Examples/LoupeExample/LoupeExample/ViewController.swift
@@ -1071,7 +1071,10 @@ private struct SwiftUIFixtureRows: View {
                 }
                 .padding(.vertical, 4)
                 .accessibilityIdentifier("example.fixtures.swiftui.row.\(index)")
-                .localLoupeProbe("example.fixtures.swiftui.row.\(index)", label: "iOS SwiftUI row \(index)")
+                .localLoupeProbe(
+                    "example.fixtures.swiftui.row.\(index)",
+                    label: "iOS SwiftUI row \(index)"
+                )
             }
         }
         .padding(12)
@@ -1083,9 +1086,70 @@ private struct SwiftUIFixtureRows: View {
 
 private extension View {
     func localLoupeProbe(_ id: String, label: String? = nil) -> some View {
-        background {
-            LoupeFallbackProbeView(id: id, label: label)
+        modifier(LoupeLocalProbeModifier(id: id, label: label))
+    }
+}
+
+private struct LoupeLocalProbeModifier: ViewModifier {
+    let id: String
+    let label: String?
+
+    func body(content: Content) -> some View {
+        content
+            .background {
+                LoupeFallbackProbeView(id: id, label: label)
+            }
+            .background {
+                GeometryReader { proxy in
+                    Color.clear
+                        .onAppear {
+                            loupeRegisterRegionProbe(id, label: label, frame: proxy.frame(in: .global))
+                        }
+                        .onChange(of: proxy.frame(in: .global)) { frame in
+                            loupeRegisterRegionProbe(id, label: label, frame: frame)
+                        }
+                }
+            }
+            .onDisappear {
+                loupeRemoveProbe(id)
+            }
+    }
+
+    private func loupeRegisterRegionProbe(_ id: String, label: String?, frame: CGRect) {
+        guard frame.isFinite, !frame.isEmpty else {
+            return
         }
+
+        var userInfo: [String: Any] = [
+            "id": id,
+            "metadata": [
+                "source": "local-region-probe",
+                "loupe.swiftUI": true,
+            ],
+            "frame": [
+                "x": Double(frame.origin.x),
+                "y": Double(frame.origin.y),
+                "width": Double(frame.width),
+                "height": Double(frame.height),
+            ],
+        ]
+        if let label {
+            userInfo["label"] = label
+        }
+
+        NotificationCenter.default.post(
+            name: Notification.Name("dev.loupe.probe"),
+            object: nil,
+            userInfo: userInfo
+        )
+    }
+
+    private func loupeRemoveProbe(_ id: String) {
+        NotificationCenter.default.post(
+            name: Notification.Name("dev.loupe.removeProbe"),
+            object: nil,
+            userInfo: ["id": id]
+        )
     }
 }
 
@@ -1117,10 +1181,17 @@ private struct LoupeFallbackProbeView: UIViewRepresentable {
             object: view,
             userInfo: [
                 "metadata": [
+                    "loupe.probe": true,
                     "loupe.swiftUI": true,
                 ],
             ]
         )
+    }
+}
+
+private extension CGRect {
+    var isFinite: Bool {
+        origin.x.isFinite && origin.y.isFinite && width.isFinite && height.isFinite
     }
 }
 

--- a/Sources/LoupeCore/AccessibilityTree.swift
+++ b/Sources/LoupeCore/AccessibilityTree.swift
@@ -204,7 +204,9 @@ public struct LoupeAccessibilityTree: Codable, Equatable {
         surfaceVisibleRefs: Set<String>?,
         snapshot: LoupeSnapshot
     ) -> Bool {
-        if !includeHidden, !isVisible(node, in: snapshot, visibilityMode: visibilityMode, surfaceVisibleRefs: surfaceVisibleRefs) {
+        if !includeHidden,
+           !isVisible(node, in: snapshot, visibilityMode: visibilityMode, surfaceVisibleRefs: surfaceVisibleRefs),
+           !isVisibleAppAuthoredProbe(node, screen: snapshot.screen) {
             return false
         }
 
@@ -227,6 +229,24 @@ public struct LoupeAccessibilityTree: Codable, Equatable {
             return true
         }
         return accessibility?.traits.isEmpty == false
+    }
+
+    private static func isVisibleAppAuthoredProbe(_ node: LoupeNode, screen: LoupeScreen) -> Bool {
+        guard node.isVisible,
+              node.accessibility?.isElement == true,
+              node.custom["loupe.probe"] == .bool(true) || node.custom["loupe.swiftUI"] == .bool(true),
+              let frame = node.accessibility?.frame ?? node.frame,
+              !frame.isEmpty else {
+            return false
+        }
+
+        let screenRect = LoupeRect(
+            x: 0,
+            y: 0,
+            width: screen.size.width,
+            height: screen.size.height
+        )
+        return screenRect.isEmpty || frame.intersects(screenRect)
     }
 
     private static func isVisible(

--- a/Sources/LoupeKit/LoupeAgent.swift
+++ b/Sources/LoupeKit/LoupeAgent.swift
@@ -101,7 +101,18 @@ public final class LoupeAgent {
             sceneRefs.append(sceneRef)
         }
 
-        let registeredProbeRefs = runtime.registeredProbes().map { probe in
+        let materializedProbeIDs = Set(nodes.values.compactMap { node -> String? in
+            guard node.isVisible,
+                  let testID = node.testID ?? stringMetadata("id", from: node.custom) else {
+                return nil
+            }
+            return testID
+        })
+
+        let registeredProbeRefs: [String] = runtime.registeredProbes().compactMap { probe in
+            guard !materializedProbeIDs.contains(probe.id) else {
+                return nil
+            }
             let ref = makeRef()
             nodes[ref] = loupeRegisteredProbeNode(
                 probe,
@@ -264,11 +275,14 @@ public final class LoupeAgent {
         let ref = makeRef()
         viewRefs[ObjectIdentifier(view)] = ref
         viewsByRef[ref] = view
-        let visible = inheritedVisible
-            && view.isHidden == false
+        let testID = view.accessibilityIdentifier ?? stringMetadata("id", from: view.loupeMetadata)
+        let customMetadata = mergedMetadata(view.loupeMetadata, with: runtime.metadata(forTestID: testID))
+        let directlyVisible = view.isHidden == false
             && view.alpha > 0.01
             && view.bounds.width > 0
             && view.bounds.height > 0
+        let visible = directlyVisible
+            && (inheritedVisible || isAppAuthoredProbe(customMetadata))
 
         var childRefs: [String] = []
         for subview in view.subviews {
@@ -299,8 +313,6 @@ public final class LoupeAgent {
             )
         )
 
-        let testID = view.accessibilityIdentifier ?? stringMetadata("id", from: view.loupeMetadata)
-        let customMetadata = mergedMetadata(view.loupeMetadata, with: runtime.metadata(forTestID: testID))
         let accessibility = accessibility(for: view)
         let runtimeProperties = runtimeProperties(for: view)
         let uiKitProperties = uiKitProperties(for: view)
@@ -1017,6 +1029,21 @@ private func stringMetadata(
         return nil
     }
     return value
+}
+
+private func boolMetadata(
+    _ key: String,
+    from metadata: [String: LoupeMetadataValue]
+) -> Bool {
+    guard case let .bool(value) = metadata[key] else {
+        return false
+    }
+    return value
+}
+
+private func isAppAuthoredProbe(_ metadata: [String: LoupeMetadataValue]) -> Bool {
+    boolMetadata("loupe.probe", from: metadata)
+        || boolMetadata("loupe.swiftUI", from: metadata)
 }
 
 private func nonEmpty(_ value: String?) -> String? {

--- a/Tests/LoupeCoreTests/AccessibilityTreeTests.swift
+++ b/Tests/LoupeCoreTests/AccessibilityTreeTests.swift
@@ -156,6 +156,72 @@ struct AccessibilityTreeTests {
         #expect(tree.nodes["ax-button"]?.activationPoint == nil)
     }
 
+    @Test func accessibilityTreeKeepsVisibleAppAuthoredProbeWhenSurfaceOccluded() throws {
+        let probeFrame = LoupeRect(x: 0, y: 143, width: 390, height: 600)
+        let snapshot = LoupeSnapshot(
+            id: "s1",
+            capturedAt: Date(timeIntervalSince1970: 0),
+            screen: LoupeScreen(size: LoupeSize(width: 390, height: 844), scale: 3),
+            rootRefs: ["root"],
+            nodes: [
+                "root": LoupeNode(
+                    ref: "root",
+                    parentRef: nil,
+                    kind: .view,
+                    typeName: "UIView",
+                    frame: LoupeRect(x: 0, y: 0, width: 390, height: 844),
+                    isVisible: true,
+                    isEnabled: true,
+                    isInteractive: false,
+                    children: ["probe", "cover"]
+                ),
+                "probe": LoupeNode(
+                    ref: "probe",
+                    parentRef: "root",
+                    kind: .view,
+                    typeName: "UIView",
+                    testID: "example.fixtures.swiftui.probe",
+                    label: "iOS SwiftUI probe",
+                    frame: probeFrame,
+                    isVisible: true,
+                    isEnabled: true,
+                    isInteractive: false,
+                    accessibility: LoupeAccessibility(
+                        identifier: "example.fixtures.swiftui.probe",
+                        label: "iOS SwiftUI probe",
+                        frame: probeFrame,
+                        isElement: true
+                    ),
+                    custom: [
+                        "loupe.probe": .bool(true),
+                        "loupe.swiftUI": .bool(true),
+                    ]
+                ),
+                "cover": LoupeNode(
+                    ref: "cover",
+                    parentRef: "root",
+                    kind: .view,
+                    typeName: "UIView",
+                    frame: probeFrame,
+                    isVisible: true,
+                    isEnabled: true,
+                    isInteractive: false,
+                    style: LoupeStyle(
+                        backgroundColor: LoupeColor(red: 1, green: 1, blue: 1, alpha: 1)
+                    )
+                ),
+            ]
+        )
+
+        #expect(!LoupeSurfaceVisibility.visibleNodeRefs(in: snapshot, includesOffscreen: true).contains("probe"))
+
+        let tree = LoupeAccessibilityTree.build(from: snapshot)
+        let probeNode = try #require(tree.nodes["ax-probe"])
+        #expect(probeNode.sourceRef == "probe")
+        #expect(probeNode.testID == "example.fixtures.swiftui.probe")
+        #expect(probeNode.label == "iOS SwiftUI probe")
+    }
+
     @Test func accessibilityTreeKeepsAccessibilityValueAndHintOnlyNodes() throws {
         let snapshot = LoupeSnapshot(
             id: "s1",


### PR DESCRIPTION
## What is this PR?

On iOS 18.6, the SwiftUI fixture could lose probe nodes that were attached through background UIViewRepresentables. The screen was still visible, but the snapshot missed `example.fixtures.swiftui.controls`, `example.fixtures.swiftui.rows`, and `example.fixtures.swiftui.row.1`.

This keeps `.localLoupeProbe(...)` as the fixture-facing API. Internally, the helper still installs the UIViewRepresentable probe and also registers measured bounds through Loupe's probe notification path. The snapshot builder prefers the real visible view when it exists, so the registered probe only fills the gap.

The accessibility tree also keeps visible app-authored probes queryable when generic surface visibility would otherwise drop them.

## Validation

- `scripts/verify-agent-work.sh`
- Focused iOS 18.6 SwiftUI route on iPhone 12 Pro Max: `controls`, `rows`, and `row.1` probes are present, and the root probe remains a single `UIView` node.

Fixes #3