### PR TITLE
Improve tap navigation diagnostics

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -12,7 +12,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  LOUPE_SIMCTL_LIST_TIMEOUT: "90"
+  LOUPE_SIMCTL_LIST_TIMEOUT: "120"
+  LOUPE_CI_SIMCTL_LIST_ATTEMPTS: "3"
+  LOUPE_CI_ATTEMPTS: "2"
+  LOUPE_CI_RETRY_SLEEP: "10"
   LOUPE_SIMCTL_TERMINATE_TIMEOUT: "20"
 
 jobs:
@@ -26,9 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Print toolchain
-        run: |
-          swift --version
-          xcodebuild -version
+        run: scripts/ci-print-toolchain.sh
 
       - name: Run SwiftPM tests
         run: swift test
@@ -43,10 +44,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Print toolchain
-        run: |
-          swift --version
-          xcodebuild -version
-          perl -e 'alarm 90; exec @ARGV' xcrun simctl list devices available
+        run: scripts/ci-print-toolchain.sh --simulators
 
       - name: Release CLI build
         run: swift build --configuration release --disable-sandbox --product loupe
@@ -73,9 +71,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Print toolchain
-        run: |
-          swift --version
-          xcodebuild -version
+        run: scripts/ci-print-toolchain.sh
 
       - name: Run macOS example E2E
         run: scripts/ci-run-with-diagnostics.sh "macOS E2E" Examples/MacLoupeExample/run-macos-e2e.sh
@@ -88,6 +84,7 @@ jobs:
           if-no-files-found: ignore
           path: |
             /tmp/loupe-macos-*
+            /tmp/loupe-ci-*
 
   tvos-e2e:
     name: tvOS E2E
@@ -99,10 +96,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Print toolchain
-        run: |
-          swift --version
-          xcodebuild -version
-          perl -e 'alarm 90; exec @ARGV' xcrun simctl list devices available
+        run: scripts/ci-print-toolchain.sh --simulators
 
       - name: Run tvOS example E2E
         run: scripts/ci-run-with-diagnostics.sh "tvOS E2E" Examples/LoupeTVExample/run-tvos-runtime-e2e.sh
@@ -115,6 +109,7 @@ jobs:
           if-no-files-found: ignore
           path: |
             /tmp/loupe-tvos-*
+            /tmp/loupe-ci-*
 
   watchos-e2e:
     name: watchOS E2E
@@ -126,10 +121,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Print toolchain
-        run: |
-          swift --version
-          xcodebuild -version
-          perl -e 'alarm 90; exec @ARGV' xcrun simctl list devices available
+        run: scripts/ci-print-toolchain.sh --simulators
 
       - name: Run watchOS example E2E
         run: scripts/ci-run-with-diagnostics.sh "watchOS E2E" Examples/LoupeWatchExample/run-watchos-runtime-e2e.sh
@@ -142,6 +134,7 @@ jobs:
           if-no-files-found: ignore
           path: |
             /tmp/loupe-watchos-*
+            /tmp/loupe-ci-*
 
   ios-injected-e2e:
     name: iOS Injected E2E
@@ -155,10 +148,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Print toolchain
-        run: |
-          swift --version
-          xcodebuild -version
-          perl -e 'alarm 90; exec @ARGV' xcrun simctl list devices available
+        run: scripts/ci-print-toolchain.sh --simulators
 
       - name: Run injected log E2E
         run: scripts/ci-run-with-diagnostics.sh "iOS Injected E2E" Examples/LoupeExample/run-injected.sh
@@ -171,6 +161,7 @@ jobs:
           if-no-files-found: ignore
           path: |
             /tmp/loupe-example-*
+            /tmp/loupe-ci-*
             /tmp/loupe-injector-build.log
 
   ios-runtime-e2e:
@@ -185,10 +176,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Print toolchain
-        run: |
-          swift --version
-          xcodebuild -version
-          perl -e 'alarm 90; exec @ARGV' xcrun simctl list devices available
+        run: scripts/ci-print-toolchain.sh --simulators
 
       - name: Run runtime E2E
         run: scripts/ci-run-with-diagnostics.sh "iOS Runtime E2E" Examples/LoupeExample/run-runtime-e2e.sh
@@ -201,6 +189,7 @@ jobs:
           if-no-files-found: ignore
           path: |
             /tmp/loupe-runtime-*
+            /tmp/loupe-ci-*
             /tmp/loupe-example-build.log
             /tmp/loupe-injector-build.log
 
@@ -216,10 +205,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Print toolchain
-        run: |
-          swift --version
-          xcodebuild -version
-          perl -e 'alarm 90; exec @ARGV' xcrun simctl list devices available
+        run: scripts/ci-print-toolchain.sh --simulators
 
       - name: Run native scenario E2E
         run: scripts/ci-run-with-diagnostics.sh "iOS Native Scenario E2E" Examples/LoupeExample/run-native-scenarios.sh
@@ -232,6 +218,7 @@ jobs:
           if-no-files-found: ignore
           path: |
             /tmp/loupe-native-*
+            /tmp/loupe-ci-*
             /tmp/loupe-example-build.log
             /tmp/loupe-injector-build.log
 
@@ -247,10 +234,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Print toolchain
-        run: |
-          swift --version
-          xcodebuild -version
-          perl -e 'alarm 90; exec @ARGV' xcrun simctl list devices available
+        run: scripts/ci-print-toolchain.sh --simulators
 
       - name: Run bookmark E2E
         run: scripts/ci-run-with-diagnostics.sh "iOS Bookmark E2E" Examples/LoupeExample/run-bookmark-e2e.sh
@@ -263,5 +247,6 @@ jobs:
           if-no-files-found: ignore
           path: |
             /tmp/loupe-bookmark-*
+            /tmp/loupe-ci-*
             /tmp/loupe-example-build.log
             /tmp/loupe-injector-build.log

--- a/Examples/LoupeExample/run-native-scenarios.sh
+++ b/Examples/LoupeExample/run-native-scenarios.sh
@@ -244,7 +244,7 @@ assert_query example.customerList /tmp/loupe-native-list-query.json
 
 echo "case: navigation push by testID tap, then pop by ref tap"
 launch_app
-.build/debug/loupe act tap --host "$HOST" --udid "$DEVICE" --test-id example.openComponents --trace-dir "$TRACE_DIR"
+.build/debug/loupe act tap --host "$HOST" --udid "$DEVICE" --test-id example.openComponents --trace-dir "$TRACE_DIR" --expect-visible example.components
 .build/debug/loupe act wait visible --host "$HOST" --test-id example.components --timeout 5 >/tmp/loupe-native-wait-components.json
 fetch_snapshot
 assert_query example.components /tmp/loupe-native-components-query.json

--- a/Sources/LoupeCLI/CaptureReportOptions.swift
+++ b/Sources/LoupeCLI/CaptureReportOptions.swift
@@ -15,7 +15,7 @@ struct CaptureReportOptions {
         hostWasExplicit = false
         udid = nil
         bundleID = nil
-        outputDirectory = URL(fileURLWithPath: "loupe-report")
+        outputDirectory = Self.defaultOutputDirectory()
         screenMapLimit = 120
         timeout = 5
 
@@ -69,5 +69,15 @@ struct CaptureReportOptions {
             throw CLIError("\(option) expects a number")
         }
         return value
+    }
+
+    private static func defaultOutputDirectory() -> URL {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let stamp = formatter.string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+        return FileManager.default.temporaryDirectory
+            .appendingPathComponent("loupe-report-\(stamp)", isDirectory: true)
     }
 }

--- a/Sources/LoupeCLI/DiagnosticCommands.swift
+++ b/Sources/LoupeCLI/DiagnosticCommands.swift
@@ -32,7 +32,11 @@ extension LoupeCLI {
             try await runtimeFetch(
                 rest,
                 path: "/logs",
-                usage: "loupe debug logs [--host <url>] [--udid <sim>] [--bundle-id <id>] [--output <path>]"
+                usage: """
+                loupe debug logs [--host <url>] [--udid <sim>] [--bundle-id <id>] [--output <path>]
+
+                Apps without a LoupeKit import can post NotificationCenter name "dev.loupe.log" with userInfo keys level, message, and metadata.
+                """
             )
         case "network":
             try await runtimeFetch(

--- a/Sources/LoupeCLI/LoupeCLI.swift
+++ b/Sources/LoupeCLI/LoupeCLI.swift
@@ -323,25 +323,46 @@ struct LoupeCLI {
 
     static func query(_ arguments: [String]) async throws {
         let options = try QueryOptions(arguments)
-        let snapshot: LoupeSnapshot
         if let snapshotURL = options.snapshotURL {
             let data = try Data(contentsOf: snapshotURL)
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
-            snapshot = try decoder.decode(LoupeSnapshot.self, from: data)
-        } else {
-            let host = try await resolvedRuntimeHost(
-                requestedHost: options.host,
-                hostWasExplicit: options.hostWasExplicit,
-                udid: options.udid,
-                bundleID: options.bundleID
-            )
-            if let udid = options.udid {
-                try await validateRuntimeIdentity(host: host, expectedUDID: udid, timeout: options.timeout)
-            }
-            snapshot = try await fetchSnapshot(host: host, timeout: options.timeout)
+            let snapshot = try decoder.decode(LoupeSnapshot.self, from: data)
+            let result = try queryResultData(snapshot: snapshot, options: options)
+            FileHandle.standardOutput.write(result.data)
+            FileHandle.standardOutput.write(Data("\n".utf8))
+            return
         }
 
+        let host = try await resolvedRuntimeHost(
+            requestedHost: options.host,
+            hostWasExplicit: options.hostWasExplicit,
+            udid: options.udid,
+            bundleID: options.bundleID
+        )
+        if let udid = options.udid {
+            try await validateRuntimeIdentity(host: host, expectedUDID: udid, timeout: options.timeout)
+        }
+        let deadline = Date().addingTimeInterval(options.timeout)
+        while true {
+            let fetchTimeout = options.waitForMatch
+                ? min(3, max(0.1, deadline.timeIntervalSinceNow))
+                : options.timeout
+            let snapshot = try await fetchSnapshot(host: host, timeout: fetchTimeout)
+            let result = try queryResultData(snapshot: snapshot, options: options)
+            if !options.waitForMatch || result.count > 0 || Date() >= deadline {
+                FileHandle.standardOutput.write(result.data)
+                FileHandle.standardOutput.write(Data("\n".utf8))
+                return
+            }
+            try await sleep(seconds: min(0.25, max(0.01, deadline.timeIntervalSinceNow)))
+        }
+    }
+
+    private static func queryResultData(
+        snapshot: LoupeSnapshot,
+        options: QueryOptions
+    ) throws -> (data: Data, count: Int) {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let context = LoupeSnapshotContext(snapshot: snapshot)
@@ -356,7 +377,7 @@ struct LoupeCLI {
                     maxResults: options.maxResults
                 )
             )
-            FileHandle.standardOutput.write(try encoder.encode(results))
+            return (try encoder.encode(results), results.count)
         case .accessibility:
             let tree = LoupeAccessibilityTree.build(from: context, includeHidden: options.includeHidden)
             let results = LoupeAccessibilityTreeQuery.find(
@@ -368,9 +389,8 @@ struct LoupeCLI {
                     maxResults: options.maxResults
                 )
             )
-            FileHandle.standardOutput.write(try encoder.encode(results))
+            return (try encoder.encode(results), results.count)
         }
-        FileHandle.standardOutput.write(Data("\n".utf8))
     }
 
     static func accessibility(_ arguments: [String]) throws {
@@ -3149,6 +3169,8 @@ struct LoupeCLI {
             press: options.press,
             resolvedPoint: target?.point,
             resolvedScreen: target?.screen,
+            coordinateUnit: target == nil ? nil : "points",
+            resolvedScreenScale: target?.screenScale,
             resolvedSource: target?.source.description,
             resolvedTarget: target?.match?.trace,
             recordedAt: Date()

--- a/Sources/LoupeCLI/LoupeCLIUsage.swift
+++ b/Sources/LoupeCLI/LoupeCLIUsage.swift
@@ -89,7 +89,7 @@ extension LoupeCLI {
         case "app cleanup":
             return "Usage: loupe app cleanup [--dry-run] [--timeout <seconds>]"
         case "ui report":
-            return "Usage: loupe ui report [--host <url>] [--udid <sim>] [--bundle-id <id>] --output <dir> [--screen-map-limit <n>] [--timeout <seconds>]"
+            return "Usage: loupe ui report [--host <url>] [--udid <sim>] [--bundle-id <id>] [--output <dir>] [--screen-map-limit <n>] [--timeout <seconds>]"
         case "ui snapshot":
             return "Usage: loupe ui snapshot [--host <url>] [--udid <sim>] [--bundle-id <id>] [--output <path>] [--timeout <seconds>]"
         case "ui compact":
@@ -144,7 +144,11 @@ extension LoupeCLI {
         case "ui apply-design-suggestions":
             return ApplyDesignSuggestionsOptions.usage
         case "act tap":
-            return "Usage: loupe act tap (--test-id <id> | --ref <view-or-ax-ref> | --x <n> --y <n>) [--udid <sim>] [--host <url>] [--backend native|runtime|auto] [--snapshot <snapshot.json>] [--trace-dir <path>] [--expect-visible <testID>] [--timeout <seconds>]"
+            return """
+            Usage: loupe act tap (--test-id <id> | --ref <view-or-ax-ref> | --x <n> --y <n>) [--udid <sim>] [--host <url>] [--backend native|runtime|auto] [--snapshot <snapshot.json>] [--trace-dir <path>] [--expect-visible <testID>] [--timeout <seconds>]
+
+            Coordinates are screen points, not screenshot pixels. Trace files include coordinateUnit, resolvedScreen, and resolvedScreenScale.
+            """
         case "act swipe":
             return "Usage: loupe act swipe --from x,y --to x,y [--udid <sim>] [--host <url>] [--duration <seconds>] [--no-verify-scroll] [--trace-dir <path>] [--timeout <seconds>]"
         case "act drag":
@@ -159,7 +163,11 @@ extension LoupeCLI {
                    loupe act wait value (--test-id <id> | --ref <ref> | --text <text> | --role <role>) --key <path> --equals <value> [--host <url>] [--udid <sim>] [--bundle-id <id>] [--timeout <seconds>] [--interval <seconds>] [--output <path>]
             """
         case "debug logs":
-            return "Usage: loupe debug logs [--host <url>] [--udid <sim>] [--bundle-id <id>] [--output <path>]"
+            return """
+            Usage: loupe debug logs [--host <url>] [--udid <sim>] [--bundle-id <id>] [--output <path>]
+
+            Apps without a LoupeKit import can post NotificationCenter name "dev.loupe.log" with userInfo keys level, message, and metadata.
+            """
         case "debug network":
             return "Usage: loupe debug network [--host <url>] [--udid <sim>] [--bundle-id <id>] [--output <path>]"
         case "debug refs":

--- a/Sources/LoupeCLI/QueryOptions.swift
+++ b/Sources/LoupeCLI/QueryOptions.swift
@@ -12,6 +12,7 @@ struct QueryOptions {
     var includeHidden: Bool
     var maxResults: Int
     var tree: QueryTree
+    var waitForMatch: Bool
     var timeout: TimeInterval
 
     init(_ arguments: [String]) throws {
@@ -27,6 +28,7 @@ struct QueryOptions {
         includeHidden = false
         maxResults = 50
         tree = .view
+        waitForMatch = false
         timeout = 5
 
         var selector: LoupeSelector?
@@ -73,6 +75,8 @@ struct QueryOptions {
                     throw CLIError("--tree expects view or accessibility")
                 }
                 tree = value
+            case "--wait":
+                waitForMatch = true
             case "--timeout":
                 timeout = try Self.double(after: "--timeout", in: arguments, index: &index)
             default:
@@ -85,6 +89,9 @@ struct QueryOptions {
         guard let selector else {
             throw CLIError("query requires one selector option")
         }
+        if waitForMatch, snapshotURL != nil {
+            throw CLIError("--wait requires a live runtime query; omit snapshot.json")
+        }
 
         self.selector = selector
         guard timeout > 0 else {
@@ -92,7 +99,7 @@ struct QueryOptions {
         }
     }
 
-    static let usage = "Usage: loupe ui query [snapshot.json] (--test-id <id> | --text <text> | --exact-text <text> | --role <role> | --ref <ref>) [--host <url>] [--udid <sim>] [--bundle-id <id>] [--tree view|accessibility] [--include-hidden] [--max-results <n>] [--timeout <seconds>]"
+    static let usage = "Usage: loupe ui query [snapshot.json] (--test-id <id> | --text <text> | --exact-text <text> | --role <role> | --ref <ref>) [--host <url>] [--udid <sim>] [--bundle-id <id>] [--tree view|accessibility] [--include-hidden] [--max-results <n>] [--wait] [--timeout <seconds>]"
 
     private static func value(
         after option: String,

--- a/Sources/LoupeCLIModel/ActionTrace.swift
+++ b/Sources/LoupeCLIModel/ActionTrace.swift
@@ -64,6 +64,8 @@ package struct LoupeCLIActionTrace: Codable, Equatable {
     package var press: String?
     package var resolvedPoint: LoupePoint?
     package var resolvedScreen: LoupeSize?
+    package var coordinateUnit: String?
+    package var resolvedScreenScale: Double?
     package var resolvedSource: String?
     package var resolvedTarget: ActionTargetTrace?
     package var recordedAt: Date
@@ -82,6 +84,8 @@ package struct LoupeCLIActionTrace: Codable, Equatable {
         press: String? = nil,
         resolvedPoint: LoupePoint?,
         resolvedScreen: LoupeSize?,
+        coordinateUnit: String? = nil,
+        resolvedScreenScale: Double? = nil,
         resolvedSource: String?,
         resolvedTarget: ActionTargetTrace?,
         recordedAt: Date
@@ -99,6 +103,8 @@ package struct LoupeCLIActionTrace: Codable, Equatable {
         self.press = press
         self.resolvedPoint = resolvedPoint
         self.resolvedScreen = resolvedScreen
+        self.coordinateUnit = coordinateUnit
+        self.resolvedScreenScale = resolvedScreenScale
         self.resolvedSource = resolvedSource
         self.resolvedTarget = resolvedTarget
         self.recordedAt = recordedAt

--- a/Tests/LoupeCLIModelTests/RuntimeActionModelsTests.swift
+++ b/Tests/LoupeCLIModelTests/RuntimeActionModelsTests.swift
@@ -154,6 +154,8 @@ struct RuntimeActionModelsTests {
             press: nil,
             resolvedPoint: LoupePoint(x: 201, y: 735),
             resolvedScreen: LoupeSize(width: 402, height: 874),
+            coordinateUnit: "points",
+            resolvedScreenScale: 3,
             resolvedSource: ActionTargetSource.coordinates.description,
             resolvedTarget: nil,
             recordedAt: Date(timeIntervalSince1970: 0)
@@ -164,6 +166,8 @@ struct RuntimeActionModelsTests {
 
         #expect(decoded.command == "swipe")
         #expect(decoded.resolvedScreen == LoupeSize(width: 402, height: 874))
+        #expect(decoded.coordinateUnit == "points")
+        #expect(decoded.resolvedScreenScale == 3)
         #expect(decoded.resolvedSource == "coordinates")
         #expect(decoded.endPoint == LoupePoint(x: 201, y: 300))
     }

--- a/Tests/LoupeCLITests/CLIHelpTests.swift
+++ b/Tests/LoupeCLITests/CLIHelpTests.swift
@@ -53,11 +53,11 @@ import Testing
             "app current": "Usage: loupe app current [--json] [--timeout <seconds>]",
             "app info": "Usage: loupe app info [--host <url>] [--udid <sim>] [--bundle-id <id>] [--output <path>]",
             "ui": "Usage: loupe ui <subcommand>",
-            "ui report": "Usage: loupe ui report [--host <url>] [--udid <sim>] [--bundle-id <id>] --output <dir> [--screen-map-limit <n>] [--timeout <seconds>]",
+            "ui report": "Usage: loupe ui report [--host <url>] [--udid <sim>] [--bundle-id <id>] [--output <dir>] [--screen-map-limit <n>] [--timeout <seconds>]",
             "ui snapshot": "Usage: loupe ui snapshot [--host <url>] [--udid <sim>] [--bundle-id <id>] [--output <path>] [--timeout <seconds>]",
             "ui tree": "Usage: loupe ui tree [snapshot.json] [--host <url>] [--udid <sim>] [--bundle-id <id>] [--view|--accessibility] [--depth <n>]",
             "ui node": "Usage: loupe ui node <snapshot.json> (--test-id <id> | --text <text> | --role <role> | --ref <ref>) [--include-hidden] [--fields node,parent,children,siblings]",
-            "ui query": "Usage: loupe ui query [snapshot.json] (--test-id <id> | --text <text> | --exact-text <text> | --role <role> | --ref <ref>) [--host <url>] [--udid <sim>] [--bundle-id <id>] [--tree view|accessibility] [--include-hidden] [--max-results <n>] [--timeout <seconds>]",
+            "ui query": "Usage: loupe ui query [snapshot.json] (--test-id <id> | --text <text> | --exact-text <text> | --role <role> | --ref <ref>) [--host <url>] [--udid <sim>] [--bundle-id <id>] [--tree view|accessibility] [--include-hidden] [--max-results <n>] [--wait] [--timeout <seconds>]",
             "ui compare-design": "Usage: loupe ui compare-design <snapshot.json> <design.json> [--json] [--suggest-mutations] [--host <url>] [--limit <n>] [--frame-tolerance <n>] [--color-tolerance <n>] [--corner-radius-tolerance <n>] [--font-size-tolerance <n>] [--max-match-distance <n>] [--no-unexpected]",
             "ui apply-design-suggestions": "Usage: loupe ui apply-design-suggestions <compare-design.json> [--host <url>] [--snapshot <snapshot.json>] [--output-dir <dir>] [--max <n>] [--properties <list>] [--dry-run]",
             "ui set": "Usage: loupe ui set (--test-id <id> | --ref <ref> | --role <role> | --text <text>) <property> <value> [--host <url>] [--udid <sim>] [--bundle-id <id>] [--snapshot <snapshot.json>] [--include-hidden] [--output <path>]",
@@ -176,6 +176,13 @@ import Testing
         for command in publicCommands {
             #expect(LoupeCLI.commandUsage(command) != nil)
         }
+    }
+
+    @Test func debugLogsHelpMentionsNoImportNotificationBridge() throws {
+        let help = try #require(LoupeCLI.commandUsage("debug logs"))
+
+        #expect(help.contains("dev.loupe.log"))
+        #expect(help.contains("NotificationCenter"))
     }
 
     @Test func ambiguousCompatibilityCommandsAreNotPublic() {

--- a/Tests/LoupeCLITests/CaptureReportOptionsTests.swift
+++ b/Tests/LoupeCLITests/CaptureReportOptionsTests.swift
@@ -1,4 +1,5 @@
 @testable import LoupeCLI
+import Foundation
 import Testing
 
 @Suite struct CaptureReportOptionsTests {
@@ -18,12 +19,13 @@ import Testing
         #expect(options.timeout == 3)
     }
 
-    @Test func defaultsToCurrentRuntimeAndReportDirectory() throws {
+    @Test func defaultsToCurrentRuntimeAndTemporaryReportDirectory() throws {
         let options = try CaptureReportOptions([])
 
         #expect(options.bundleID == nil)
         #expect(options.udid == nil)
-        #expect(options.outputDirectory.path.hasSuffix("loupe-report"))
+        #expect(options.outputDirectory.path.hasPrefix(FileManager.default.temporaryDirectory.path))
+        #expect(options.outputDirectory.lastPathComponent.hasPrefix("loupe-report-"))
         #expect(options.screenMapLimit == 120)
     }
 

--- a/Tests/LoupeCLITests/QueryOptionsTests.swift
+++ b/Tests/LoupeCLITests/QueryOptionsTests.swift
@@ -1,0 +1,18 @@
+@testable import LoupeCLI
+import Testing
+
+@Suite struct QueryOptionsTests {
+    @Test func parsesWaitForLiveQuery() throws {
+        let options = try QueryOptions(["--test-id", "checkout.pay", "--wait", "--timeout", "2"])
+
+        #expect(options.waitForMatch)
+        #expect(options.timeout == 2)
+        #expect(options.snapshotURL == nil)
+    }
+
+    @Test func rejectsWaitForSnapshotQuery() {
+        #expect(throws: (any Error).self) {
+            _ = try QueryOptions(["/tmp/snapshot.json", "--test-id", "checkout.pay", "--wait"])
+        }
+    }
+}

--- a/scripts/ci-print-toolchain.sh
+++ b/scripts/ci-print-toolchain.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INCLUDE_SIMULATORS=0
+for argument in "$@"; do
+  case "$argument" in
+    --simulators)
+      INCLUDE_SIMULATORS=1
+      ;;
+    *)
+      echo "usage: $0 [--simulators]" >&2
+      exit 64
+      ;;
+  esac
+done
+
+positive_int_or_default() {
+  local value="$1"
+  local fallback="$2"
+  case "$value" in
+    ''|*[!0-9]*)
+      printf '%s\n' "$fallback"
+      return
+      ;;
+  esac
+  if [[ "$value" -le 0 ]]; then
+    printf '%s\n' "$fallback"
+  else
+    printf '%s\n' "$value"
+  fi
+}
+
+swift --version
+xcodebuild -version
+
+if [[ "$INCLUDE_SIMULATORS" -eq 0 ]]; then
+  exit 0
+fi
+
+TIMEOUT="$(positive_int_or_default "${LOUPE_SIMCTL_LIST_TIMEOUT:-120}" 120)"
+ATTEMPTS="$(positive_int_or_default "${LOUPE_CI_SIMCTL_LIST_ATTEMPTS:-3}" 3)"
+STATUS=0
+
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  LOG_PATH="/tmp/loupe-ci-simctl-list-devices-attempt-${attempt}.log"
+  echo "simctl list devices available attempt ${attempt}/${ATTEMPTS} (timeout ${TIMEOUT}s)"
+  if perl -e 'alarm shift @ARGV; exec @ARGV' "$TIMEOUT" xcrun simctl list devices available >"$LOG_PATH" 2>&1; then
+    cat "$LOG_PATH"
+    exit 0
+  fi
+
+  STATUS=$?
+  echo "::warning title=simctl list attempt ${attempt} failed::xcrun simctl list devices available exited with ${STATUS}; see ${LOG_PATH}"
+  tail -40 "$LOG_PATH" || true
+  if [[ "$attempt" -lt "$ATTEMPTS" ]]; then
+    sleep 5
+  fi
+done
+
+echo "::error title=simctl list failed::xcrun simctl list devices available failed after ${ATTEMPTS} attempts"
+exit "$STATUS"

--- a/scripts/ci-run-with-diagnostics.sh
+++ b/scripts/ci-run-with-diagnostics.sh
@@ -11,23 +11,77 @@ shift
 TAIL_LINES="${LOUPE_CI_TAIL_LINES:-120}"
 SUMMARY_BYTES="${LOUPE_CI_SUMMARY_BYTES:-1800}"
 DIAGNOSTIC_GLOBS="${LOUPE_CI_DIAGNOSTICS:-/tmp/loupe-*}"
-OUTPUT_LOG="/tmp/loupe-ci-${NAME//[^[:alnum:]._-]/-}.log"
+ATTEMPTS="${LOUPE_CI_ATTEMPTS:-1}"
+RETRY_SLEEP="${LOUPE_CI_RETRY_SLEEP:-10}"
+LOG_BASENAME="/tmp/loupe-ci-${NAME//[^[:alnum:]._-]/-}"
 
-set +e
-"$@" > >(tee "$OUTPUT_LOG") 2>&1
-STATUS=$?
-set -e
-STATUS="${STATUS:-0}"
-if [[ "$STATUS" -eq 0 ]]; then
-  exit 0
-fi
+positive_int_or_default() {
+  local value="$1"
+  local fallback="$2"
+  case "$value" in
+    ''|*[!0-9]*)
+      printf '%s\n' "$fallback"
+      return
+      ;;
+  esac
+  if [[ "$value" -le 0 ]]; then
+    printf '%s\n' "$fallback"
+  else
+    printf '%s\n' "$value"
+  fi
+}
+
+summarize_log() {
+  local log_path="$1"
+  local summary
+  summary="$(
+    tail -n 80 "$log_path" 2>/dev/null \
+      | tail -c "$SUMMARY_BYTES" \
+      | tr '\n' ' ' \
+      | sed 's/%/%25/g; s/\r/%0D/g' \
+      | cut -c 1-"$SUMMARY_BYTES"
+  )"
+  if [[ -z "$summary" ]]; then
+    printf 'Command exited without captured output'
+  else
+    printf '%s' "$summary"
+  fi
+}
+
+ATTEMPTS="$(positive_int_or_default "$ATTEMPTS" 1)"
+RETRY_SLEEP="$(positive_int_or_default "$RETRY_SLEEP" 10)"
+STATUS=0
+OUTPUT_LOG="${LOG_BASENAME}.log"
+
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  if [[ "$ATTEMPTS" -eq 1 ]]; then
+    OUTPUT_LOG="${LOG_BASENAME}.log"
+  else
+    OUTPUT_LOG="${LOG_BASENAME}-attempt-${attempt}.log"
+  fi
+
+  echo "==> ${NAME} attempt ${attempt}/${ATTEMPTS}"
+  set +e
+  "$@" > >(tee "$OUTPUT_LOG") 2>&1
+  STATUS=$?
+  set -e
+  STATUS="${STATUS:-0}"
+  if [[ "$STATUS" -eq 0 ]]; then
+    if [[ "$attempt" -gt 1 ]]; then
+      echo "::notice title=${NAME} recovered::Attempt ${attempt}/${ATTEMPTS} passed after an earlier failure"
+    fi
+    exit 0
+  fi
+
+  if [[ "$attempt" -lt "$ATTEMPTS" ]]; then
+    SUMMARY="$(summarize_log "$OUTPUT_LOG")"
+    echo "::warning title=${NAME} attempt ${attempt} failed::Command exited with status ${STATUS}. Last output: ${SUMMARY}"
+    sleep "$RETRY_SLEEP"
+  fi
+done
 
 SUMMARY="$(
-  tail -n 80 "$OUTPUT_LOG" 2>/dev/null \
-    | tail -c "$SUMMARY_BYTES" \
-    | tr '\n' ' ' \
-    | sed 's/%/%25/g; s/\r/%0D/g' \
-    | cut -c 1-"$SUMMARY_BYTES"
+  summarize_log "$OUTPUT_LOG"
 )"
 if [[ -z "$SUMMARY" ]]; then
   SUMMARY="Command exited with status ${STATUS}"


### PR DESCRIPTION
## What changed

This makes the common tap/navigation loop less brittle without adding text tap as a public action.

`loupe ui query --wait` now waits for a live query match instead of returning an empty result immediately after navigation. Action traces also record that resolved coordinates are screen points, plus the screen scale, so point vs screenshot-pixel confusion is visible in the trace.

`ui report` now defaults to a temp `loupe-report-*` directory when `--output` is omitted, and `debug logs` help mentions the no-import `NotificationCenter` bridge for `dev.loupe.log`.

The native scenario trace now waits for the components screen before capturing the after-trace, which removes a log race in that E2E.

The verify workflow now uses a retrying toolchain helper for simulator discovery, retries E2E wrapper failures once, and uploads `/tmp/loupe-ci-*` attempt logs with failure diagnostics.

## Checked

- `swift test --filter "QueryOptionsTests|CaptureReportOptionsTests|CLIHelpTests|RuntimeActionModelsTests"`
- `Examples/LoupeExample/run-native-scenarios.sh`
- `scripts/verify-agent-work.sh`
- `bash -n scripts/ci-print-toolchain.sh scripts/ci-run-with-diagnostics.sh`
- `scripts/ci-print-toolchain.sh` and `scripts/ci-print-toolchain.sh --simulators`
- `LOUPE_CI_ATTEMPTS=2 scripts/ci-run-with-diagnostics.sh ...` retry smoke
- GitHub Actions `Verify` on PR #8: all checks passed