### PR TITLE
Add accessibility action targets

### DIFF
--- a/Examples/LoupeExample/run-native-scenarios.sh
+++ b/Examples/LoupeExample/run-native-scenarios.sh
@@ -267,6 +267,43 @@ launch_app components
 .build/debug/loupe act wait visible --host "$HOST" --test-id example.components --timeout 5 >/tmp/loupe-native-wait-components-routed.json
 fetch_snapshot
 
+echo "case: accessibility action targets are copyable and one-shot"
+TARGETS_PATH="/tmp/loupe-native-action-targets.txt"
+TARGETS_RETRY_OUT="/tmp/loupe-native-action-targets-retry.out"
+TARGETS_RETRY_ERR="/tmp/loupe-native-action-targets-retry.err"
+.build/debug/loupe act targets --host "$HOST" --udid "$DEVICE" > "$TARGETS_PATH"
+grep -Eq '^App: .+$' "$TARGETS_PATH"
+if grep -Eq 'testID=|frame=|point=' "$TARGETS_PATH"; then
+  echo "error: default action targets leaked internal fields" >&2
+  exit 1
+fi
+DONE_ALIAS="$(ruby -e '
+  matches = File.readlines(ARGV.fetch(0), chomp: true).select { |line| line.match?(/\A#\d+ button "Done"\z/) }
+  abort "expected exactly one Done action target, got #{matches.inspect}" unless matches.length == 1
+  puts matches.fetch(0)[/\A#\d+/]
+' "$TARGETS_PATH")"
+.build/debug/loupe act tap "$DONE_ALIAS" --host "$HOST" --udid "$DEVICE"
+TARGET_DONE_NODE_PATH="/tmp/loupe-native-target-done-node.json"
+TARGET_DONE=false
+for _ in {1..20}; do
+  fetch_snapshot
+  if .build/debug/loupe ui node "$SNAPSHOT_PATH" --test-id example.components.button >"$TARGET_DONE_NODE_PATH" &&
+      grep -q '"renderedText" : "Done"' "$TARGET_DONE_NODE_PATH"; then
+    TARGET_DONE=true
+    break
+  fi
+  sleep 0.25
+done
+if [[ "$TARGET_DONE" != "true" ]]; then
+  echo "error: Done action target did not update the primary button within 5 seconds" >&2
+  exit 1
+fi
+if .build/debug/loupe act tap "$DONE_ALIAS" --host "$HOST" --udid "$DEVICE" >"$TARGETS_RETRY_OUT" 2>"$TARGETS_RETRY_ERR"; then
+  echo "error: consumed action target unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -q 'loupe act targets' "$TARGETS_RETRY_ERR"
+
 echo "case: UIKit component compact and inspect coverage"
 .build/debug/loupe ui compact --host "$HOST" --timeout 5 --output "$OBSERVATION_PATH"
 .build/debug/loupe ui accessibility --host "$HOST" --timeout 5 --output "$ACCESSIBILITY_PATH"

--- a/Sources/LoupeCLI/ActTargets.swift
+++ b/Sources/LoupeCLI/ActTargets.swift
@@ -1,0 +1,95 @@
+import Foundation
+import LoupeCLIModel
+import LoupeCore
+
+struct ActTargetsOptions {
+    var host: URL
+    var hostWasExplicit: Bool
+    var udid: String?
+    var timeout: TimeInterval
+
+    init(_ arguments: [String]) throws {
+        host = URL(string: "http://127.0.0.1:8765")!
+        hostWasExplicit = false
+        var udid: String?
+        var timeout: TimeInterval = 5
+        var index = 0
+
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--host":
+                let raw = try Self.value(after: argument, in: arguments, index: &index)
+                guard let url = URL(string: raw) else {
+                    throw CLIError("Invalid --host URL: \(raw)")
+                }
+                host = url
+                hostWasExplicit = true
+            case "--udid", "--device":
+                udid = try Self.value(after: argument, in: arguments, index: &index)
+            case "--timeout":
+                let raw = try Self.value(after: argument, in: arguments, index: &index)
+                guard let value = TimeInterval(raw), value > 0 else {
+                    throw CLIError("--timeout must be greater than 0")
+                }
+                timeout = value
+            default:
+                throw CLIError("Unknown targets option: \(argument)")
+            }
+            index += 1
+        }
+
+        self.udid = udid
+        self.timeout = timeout
+    }
+
+    private static func value(after option: String, in arguments: [String], index: inout Int) throws -> String {
+        let valueIndex = index + 1
+        guard valueIndex < arguments.count else {
+            throw CLIError("\(option) requires a value")
+        }
+        index = valueIndex
+        return arguments[valueIndex]
+    }
+}
+
+extension LoupeCLI {
+    static func actionTargets(_ arguments: [String]) async throws {
+        let options = try ActTargetsOptions(arguments)
+        let host = try await resolvedRuntimeHost(
+            requestedHost: options.host,
+            hostWasExplicit: options.hostWasExplicit,
+            udid: options.udid
+        )
+        let runtimeState = try await fetchRuntimeState(host: host, timeout: options.timeout)
+        if let udid = options.udid {
+            try validateRuntimeIdentity(state: runtimeState, expectedUDID: udid, host: host)
+        }
+        guard let bundleIdentifier = runtimeState.identity.bundleIdentifier?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !bundleIdentifier.isEmpty else {
+            throw CLIError("Loupe runtime did not report a bundle identifier; cannot cache action targets")
+        }
+
+        let snapshot = try await fetchSnapshot(host: host, timeout: options.timeout)
+        let accessibilityTree = try await fetchAccessibilityTree(
+            host: host,
+            fallbackSnapshot: snapshot,
+            timeout: options.timeout
+        )
+        let cache = ActionTargetAliasPlanner.makeCache(
+            snapshot: snapshot,
+            accessibilityTree: accessibilityTree,
+            runtimeIdentity: runtimeState.identity,
+            bundleIdentifier: bundleIdentifier,
+            host: host
+        )
+        try ActionTargetAliasCacheStore().store(cache)
+        print(ActionTargetAliasText.render(cache))
+        if cache.totalTargetCount > cache.targets.count {
+            FileHandle.standardError.write(Data(
+                "TIP: showing the first \(cache.targets.count) action targets; use `loupe ui report` for full view analysis\n".utf8
+            ))
+        }
+    }
+}

--- a/Sources/LoupeCLI/CommandGroups.swift
+++ b/Sources/LoupeCLI/CommandGroups.swift
@@ -136,6 +136,8 @@ extension LoupeCLI {
         }
         let rest = Array(arguments.dropFirst())
         switch subcommand {
+        case "targets":
+            try await actionTargets(rest)
         case "tap", "swipe", "drag", "type", "press":
             try await action(command: subcommand, arguments: rest)
         case "wait":

--- a/Sources/LoupeCLI/LoupeCLI.swift
+++ b/Sources/LoupeCLI/LoupeCLI.swift
@@ -2148,6 +2148,7 @@ struct LoupeCLI {
         var options = try ActionOptions(command: command, arguments: arguments)
         try validateActionBackend(options.backend)
         var target: ActionTarget?
+        var aliasCache: ActionTargetAliasCache?
         do {
             if command == "tap",
                let point = options.point,
@@ -2168,6 +2169,17 @@ struct LoupeCLI {
                 udid: options.udid
             )
             let runtimeState = try await fetchRuntimeState(host: options.host, timeout: options.timeout)
+            if let alias = options.targetAlias {
+                let cache = try ActionTargetAliasCacheStore().load()
+                try cache.validate(host: options.host, runtimeIdentity: runtimeState.identity)
+                _ = try cache.target(at: alias)
+                aliasCache = cache
+                if !options.udidWasExplicit,
+                   let deviceIdentifier = cache.deviceIdentifier,
+                   !deviceIdentifier.isEmpty {
+                    options.udid = deviceIdentifier
+                }
+            }
             options.backend = resolvedActionBackend(
                 requested: options.backend,
                 command: command,
@@ -2185,7 +2197,12 @@ struct LoupeCLI {
                 try prepareTraceDirectory(traceDirectory)
                 try await writePreActionTrace(command: command, options: options, traceDirectory: traceDirectory)
             }
-            let resolvedTarget = try await resolveActionTarget(options)
+            let resolvedTarget: ActionTarget
+            if let alias = options.targetAlias, let aliasCache {
+                resolvedTarget = try actionTarget(alias: alias, cache: aliasCache)
+            } else {
+                resolvedTarget = try await resolveActionTarget(options)
+            }
             target = resolvedTarget
             let scrollBaseline = try await scrollVerificationBaseline(
                 command: command,
@@ -2205,6 +2222,9 @@ struct LoupeCLI {
                 try await dispatchRuntimeActivation(options: options, target: resolvedTarget)
             } else {
                 try dispatchAction(command: command, options: options, target: resolvedTarget)
+            }
+            if let aliasCache {
+                try ActionTargetAliasCacheStore().consume(cacheID: aliasCache.cacheID)
             }
             try await verifyRuntimeAlive(host: options.host, timeout: options.timeout)
             if let scrollBaseline {
@@ -2232,6 +2252,17 @@ struct LoupeCLI {
             }
             throw error
         }
+    }
+
+    static func actionTarget(alias: Int, cache: ActionTargetAliasCache) throws -> ActionTarget {
+        let entry = try cache.target(at: alias)
+        return ActionTarget(
+            point: entry.point,
+            screen: cache.screen.size,
+            screenScale: cache.screen.scale,
+            source: .accessibility(ref: entry.ref, sourceRef: entry.sourceRef),
+            match: .accessibility(entry.queryResult)
+        )
     }
 
     private static func scrollVerificationBaseline(
@@ -2631,7 +2662,7 @@ struct LoupeCLI {
             .joined(separator: ", ")
     }
 
-    private static func fetchSnapshot(host: URL, timeout: TimeInterval = 5) async throws -> LoupeSnapshot {
+    static func fetchSnapshot(host: URL, timeout: TimeInterval = 5) async throws -> LoupeSnapshot {
         let url = host.appendingPathComponent("snapshot")
         let (data, response) = try await httpData(from: url, timeout: timeout, label: "snapshot fetch")
         guard let httpResponse = response as? HTTPURLResponse, (200..<300).contains(httpResponse.statusCode) else {
@@ -2786,7 +2817,7 @@ struct LoupeCLI {
             .filter { $0.isLetter || $0.isNumber }
     }
 
-    private static func fetchAccessibilityTree(
+    static func fetchAccessibilityTree(
         host: URL,
         fallbackSnapshot: LoupeSnapshot,
         timeout: TimeInterval = 5
@@ -3161,7 +3192,7 @@ struct LoupeCLI {
             host: options.host.absoluteString,
             backend: options.backend,
             udid: options.udid,
-            selector: options.selector.map(selectorDescription),
+            selector: options.targetAlias.map { "#\($0)" } ?? options.selector.map(selectorDescription),
             point: options.point,
             endPoint: options.endPoint,
             duration: options.duration,
@@ -3403,9 +3434,14 @@ struct LoupeCLI {
         }
     }
 
-    private static func dispatchRuntimeActivation(options: ActionOptions, target _: ActionTarget) async throws {
-        guard let selector = options.selector else {
-            throw CLIError("runtime tap requires --test-id or --ref")
+    private static func dispatchRuntimeActivation(options: ActionOptions, target: ActionTarget) async throws {
+        let selector: LoupeSelector
+        if let explicitSelector = options.selector {
+            selector = explicitSelector
+        } else if case let .accessibility(_, sourceRef) = target.source {
+            selector = .ref(sourceRef)
+        } else {
+            throw CLIError("runtime tap requires '#N', --test-id, or --ref")
         }
         let request = LoupeActivationRequest(selector: try activationSelector(from: selector))
         _ = try await postActivation(request, host: options.host, timeout: options.timeout)

--- a/Sources/LoupeCLI/LoupeCLIUsage.swift
+++ b/Sources/LoupeCLI/LoupeCLIUsage.swift
@@ -45,6 +45,7 @@ extension LoupeCLI {
     Usage: loupe act <subcommand>
 
     SUBCOMMANDS:
+      targets                 List lightweight accessibility action targets.
       tap                     Tap a selector, ref, or coordinate.
       swipe                   Dispatch a one-finger swipe.
       drag                    Dispatch a one-finger drag.
@@ -143,11 +144,14 @@ extension LoupeCLI {
             return CompareDesignOptions.usage
         case "ui apply-design-suggestions":
             return ApplyDesignSuggestionsOptions.usage
+        case "act targets":
+            return "Usage: loupe act targets [--udid <sim>] [--host <url>] [--timeout <seconds>]\n\nExample: loupe act targets"
         case "act tap":
             return """
-            Usage: loupe act tap (--test-id <id> | --ref <view-or-ax-ref> | --x <n> --y <n>) [--udid <sim>] [--host <url>] [--backend native|runtime|auto] [--snapshot <snapshot.json>] [--trace-dir <path>] [--expect-visible <testID>] [--timeout <seconds>]
+            Usage: loupe act tap ('#N' | --test-id <id> | --ref <view-or-ax-ref> | --x <n> --y <n>) [--udid <sim>] [--host <url>] [--backend native|runtime|auto] [--snapshot <snapshot.json>] [--trace-dir <path>] [--expect-visible <testID>] [--timeout <seconds>]
 
             Coordinates are screen points, not screenshot pixels. Trace files include coordinateUnit, resolvedScreen, and resolvedScreenScale.
+            Example: loupe act tap '#2'
             """
         case "act swipe":
             return "Usage: loupe act swipe --from x,y --to x,y [--udid <sim>] [--host <url>] [--duration <seconds>] [--no-verify-scroll] [--trace-dir <path>] [--timeout <seconds>]"

--- a/Sources/LoupeCLIModel/ActionOptions.swift
+++ b/Sources/LoupeCLIModel/ActionOptions.swift
@@ -7,8 +7,10 @@ package struct ActionOptions: ActionDispatchOptions {
     package var hostWasExplicit: Bool
     package var backend: String
     package var udid: String
+    package var udidWasExplicit: Bool
     package var timeout: TimeInterval
     package var selector: LoupeSelector?
+    package var targetAlias: Int?
     package var snapshotURL: URL?
     package var point: LoupePoint?
     package var endPoint: LoupePoint?
@@ -29,10 +31,12 @@ package struct ActionOptions: ActionDispatchOptions {
         hostWasExplicit = false
         backend = "auto"
         udid = "booted"
+        udidWasExplicit = false
         timeout = 8
         screen = LoupeSize(width: 0, height: 0)
 
         var selector: LoupeSelector?
+        var targetAlias: Int?
         var snapshotURL: URL?
         var point: LoupePoint?
         var endPoint: LoupePoint?
@@ -51,6 +55,10 @@ package struct ActionOptions: ActionDispatchOptions {
         var hasY = false
         var index = 0
 
+        if command == "tap", let first = arguments.first, !first.hasPrefix("--") {
+            targetAlias = try Self.targetAlias(first)
+            index = 1
+        }
         if command == "type", let first = arguments.first, !first.hasPrefix("--") {
             text = first
             index = 1
@@ -70,6 +78,7 @@ package struct ActionOptions: ActionDispatchOptions {
                 backend = try Self.value(after: argument, in: arguments, index: &index)
             case "--udid", "--device":
                 udid = try Self.value(after: argument, in: arguments, index: &index)
+                udidWasExplicit = true
             case "--test-id":
                 selector = .testID(try Self.value(after: argument, in: arguments, index: &index))
             case "--ref":
@@ -158,11 +167,15 @@ package struct ActionOptions: ActionDispatchOptions {
         }
 
         if command == "tap" {
-            if selector != nil, point != nil {
-                throw CLIError("tap accepts exactly one target: --test-id, --ref, or --x <n> --y <n>")
+            let targetCount = [selector != nil, point != nil, targetAlias != nil].filter { $0 }.count
+            if targetCount > 1 {
+                throw CLIError("tap accepts exactly one target: '#N', --test-id, --ref, or --x <n> --y <n>")
             }
-            if selector == nil, point == nil {
-                throw CLIError("tap requires --test-id, --ref, or --x <n> --y <n>")
+            if targetCount == 0 {
+                throw CLIError("tap requires '#N', --test-id, --ref, or --x <n> --y <n>")
+            }
+            if targetAlias != nil, snapshotURL != nil {
+                throw CLIError("tap '#N' does not accept --snapshot; rerun `loupe act targets`")
             }
         }
         if command == "press" {
@@ -172,6 +185,7 @@ package struct ActionOptions: ActionDispatchOptions {
         }
 
         self.selector = selector
+        self.targetAlias = targetAlias
         self.snapshotURL = snapshotURL
         self.point = point
         self.endPoint = endPoint
@@ -184,6 +198,20 @@ package struct ActionOptions: ActionDispatchOptions {
         self.expectVisibleTestID = expectVisibleTestID
         self.expectVisibleSelector = expectVisibleSelector
         self.verifyScroll = verifyScroll
+    }
+
+    private static func targetAlias(_ raw: String) throws -> Int {
+        guard raw.first == "#" else {
+            throw CLIError("Unknown tap target: \(raw). Use a quoted alias such as '#1', --test-id, --ref, or coordinates")
+        }
+        let digits = raw.dropFirst()
+        guard !digits.isEmpty,
+              digits.allSatisfy({ $0.isASCII && $0.isNumber }),
+              digits.first != "0",
+              let value = Int(digits) else {
+            throw CLIError("Invalid action target alias: \(raw). Run `loupe act targets` and use a quoted alias such as '#1'")
+        }
+        return value
     }
 
     private static func value(after option: String, in arguments: [String], index: inout Int) throws -> String {

--- a/Sources/LoupeCLIModel/ActionTargetAliases.swift
+++ b/Sources/LoupeCLIModel/ActionTargetAliases.swift
@@ -1,0 +1,334 @@
+import Foundation
+import LoupeCore
+
+package struct ActionTargetAliasEntry: Codable, Equatable {
+    package var index: Int
+    package var ref: String
+    package var sourceRef: String
+    package var role: String?
+    package var text: String?
+    package var testID: String?
+    package var frame: LoupeRect?
+    package var activationPoint: LoupePoint?
+    package var point: LoupePoint
+    package var isVisible: Bool
+    package var isEnabled: Bool
+    package var isInteractive: Bool
+
+    package var queryResult: LoupeAccessibilityQueryResult {
+        LoupeAccessibilityQueryResult(
+            node: LoupeAccessibilityNode(
+                ref: ref,
+                sourceRef: sourceRef,
+                role: role,
+                label: text,
+                testID: testID,
+                frame: frame,
+                activationPoint: activationPoint,
+                isVisible: isVisible,
+                isEnabled: isEnabled,
+                isInteractive: isInteractive
+            )
+        )
+    }
+}
+
+package struct ActionTargetAliasCache: Codable, Equatable {
+    package static let currentSchemaVersion = 1
+
+    package var schemaVersion: Int
+    package var cacheID: String
+    package var capturedAt: Date
+    package var launchID: String
+    package var deviceIdentifier: String?
+    package var bundleIdentifier: String
+    package var host: String
+    package var snapshotID: String
+    package var screen: LoupeScreen
+    package var totalTargetCount: Int
+    package var targets: [ActionTargetAliasEntry]
+
+    package init(
+        schemaVersion: Int = currentSchemaVersion,
+        cacheID: String = UUID().uuidString,
+        capturedAt: Date = Date(),
+        launchID: String,
+        deviceIdentifier: String?,
+        bundleIdentifier: String,
+        host: String,
+        snapshotID: String,
+        screen: LoupeScreen,
+        totalTargetCount: Int? = nil,
+        targets: [ActionTargetAliasEntry]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.cacheID = cacheID
+        self.capturedAt = capturedAt
+        self.launchID = launchID
+        self.deviceIdentifier = deviceIdentifier
+        self.bundleIdentifier = bundleIdentifier
+        self.host = ActionTargetAliasCache.normalizedHost(host)
+        self.snapshotID = snapshotID
+        self.screen = screen
+        self.totalTargetCount = totalTargetCount ?? targets.count
+        self.targets = targets
+    }
+
+    package func target(at index: Int) throws -> ActionTargetAliasEntry {
+        guard let target = targets.first(where: { $0.index == index }) else {
+            throw CLIError("Unknown action target '#\(index)'. Rerun `loupe act targets`")
+        }
+        guard target.isVisible,
+              target.isEnabled,
+              target.isInteractive,
+              target.point.x.isFinite,
+              target.point.y.isFinite,
+              target.point.x >= 0,
+              target.point.y >= 0,
+              target.point.x <= screen.size.width,
+              target.point.y <= screen.size.height else {
+            throw CLIError("Saved action target '#\(index)' is invalid. Rerun `loupe act targets`")
+        }
+        return target
+    }
+
+    package func validate(host: URL, runtimeIdentity: LoupeRuntimeIdentity) throws {
+        guard schemaVersion == Self.currentSchemaVersion else {
+            throw CLIError("Saved action targets use an unsupported format. Rerun `loupe act targets`")
+        }
+        guard self.host == Self.normalizedHost(host.absoluteString) else {
+            throw CLIError("Saved action targets belong to a different runtime host. Rerun `loupe act targets`")
+        }
+        guard launchID == runtimeIdentity.launchID else {
+            throw CLIError("Saved action targets belong to an earlier app launch. Rerun `loupe act targets`")
+        }
+        let runtimeDevice = runtimeIdentity.deviceIdentifier ?? runtimeIdentity.simulatorUDID
+        guard deviceIdentifier == runtimeDevice else {
+            throw CLIError("Saved action targets belong to a different device. Rerun `loupe act targets`")
+        }
+        guard runtimeIdentity.bundleIdentifier == bundleIdentifier else {
+            throw CLIError("Saved action targets belong to a different app. Rerun `loupe act targets`")
+        }
+    }
+
+    private static func normalizedHost(_ raw: String) -> String {
+        var value = raw
+        while value.count > 1, value.last == "/" {
+            value.removeLast()
+        }
+        return value
+    }
+}
+
+package enum ActionTargetAliasPlanner {
+    package static let maximumTargetCount = 100
+
+    package static func makeCache(
+        snapshot: LoupeSnapshot,
+        accessibilityTree: LoupeAccessibilityTree,
+        runtimeIdentity: LoupeRuntimeIdentity,
+        bundleIdentifier: String,
+        host: URL,
+        cacheID: String = UUID().uuidString,
+        capturedAt: Date = Date()
+    ) -> ActionTargetAliasCache {
+        var results = accessibilityTree.nodes.values
+            .filter { $0.isVisible && $0.isEnabled && $0.isInteractive }
+            .map(LoupeAccessibilityQueryResult.init)
+            .filter { actionPoint(for: $0, screen: accessibilityTree.screen) != nil }
+            .sorted(by: visualOrder)
+
+        results = preferPlatformBacked(results, snapshot: snapshot)
+        results = exactDedupe(results)
+
+        let totalTargetCount = results.count
+        let targets = results.prefix(maximumTargetCount).enumerated().map { offset, result in
+            ActionTargetAliasEntry(
+                index: offset + 1,
+                ref: result.ref,
+                sourceRef: result.sourceRef,
+                role: result.role,
+                text: result.text,
+                testID: result.testID,
+                frame: result.frame,
+                activationPoint: result.activationPoint,
+                point: actionPoint(for: result, screen: accessibilityTree.screen)!,
+                isVisible: result.isVisible,
+                isEnabled: result.isEnabled,
+                isInteractive: result.isInteractive
+            )
+        }
+
+        return ActionTargetAliasCache(
+            cacheID: cacheID,
+            capturedAt: capturedAt,
+            launchID: runtimeIdentity.launchID,
+            deviceIdentifier: runtimeIdentity.deviceIdentifier ?? runtimeIdentity.simulatorUDID,
+            bundleIdentifier: bundleIdentifier,
+            host: host.absoluteString,
+            snapshotID: accessibilityTree.snapshotID,
+            screen: accessibilityTree.screen,
+            totalTargetCount: totalTargetCount,
+            targets: targets
+        )
+    }
+
+    private static func actionPoint(
+        for result: LoupeAccessibilityQueryResult,
+        screen: LoupeScreen
+    ) -> LoupePoint? {
+        let point: LoupePoint?
+        if let activationPoint = result.activationPoint {
+            point = activationPoint
+        } else if let frame = result.frame, !frame.isEmpty {
+            point = LoupePoint(x: frame.x + frame.width / 2, y: frame.y + frame.height / 2)
+        } else {
+            point = nil
+        }
+        guard let point,
+              point.x.isFinite, point.y.isFinite,
+              point.x >= 0, point.y >= 0,
+              point.x <= screen.size.width,
+              point.y <= screen.size.height else {
+            return nil
+        }
+        return point
+    }
+
+    private static func visualOrder(
+        _ lhs: LoupeAccessibilityQueryResult,
+        _ rhs: LoupeAccessibilityQueryResult
+    ) -> Bool {
+        let lhsPoint = lhs.frame.map { LoupePoint(x: $0.x, y: $0.y) } ?? lhs.activationPoint ?? LoupePoint(x: 0, y: 0)
+        let rhsPoint = rhs.frame.map { LoupePoint(x: $0.x, y: $0.y) } ?? rhs.activationPoint ?? LoupePoint(x: 0, y: 0)
+        if abs(lhsPoint.y - rhsPoint.y) > 1 {
+            return lhsPoint.y < rhsPoint.y
+        }
+        if lhsPoint.x != rhsPoint.x {
+            return lhsPoint.x < rhsPoint.x
+        }
+        return lhs.ref < rhs.ref
+    }
+
+    private static func preferPlatformBacked(
+        _ results: [LoupeAccessibilityQueryResult],
+        snapshot: LoupeSnapshot
+    ) -> [LoupeAccessibilityQueryResult] {
+        let grouped = Dictionary(grouping: results, by: semanticKey)
+        let keysWithPlatformAlternative = Set(grouped.compactMap { key, group -> String? in
+            let hasSynthetic = group.contains {
+                LoupeSnapshotQuery.isSyntheticRegisteredProbeSource($0.sourceRef, in: snapshot)
+            }
+            let hasPlatform = group.contains {
+                !LoupeSnapshotQuery.isSyntheticRegisteredProbeSource($0.sourceRef, in: snapshot)
+            }
+            return hasSynthetic && hasPlatform ? key : nil
+        })
+        return results.filter { result in
+            let key = semanticKey(result)
+            return !keysWithPlatformAlternative.contains(key)
+                || !LoupeSnapshotQuery.isSyntheticRegisteredProbeSource(result.sourceRef, in: snapshot)
+        }
+    }
+
+    private static func exactDedupe(
+        _ results: [LoupeAccessibilityQueryResult]
+    ) -> [LoupeAccessibilityQueryResult] {
+        var keys = Set<String>()
+        return results.filter { keys.insert(exactKey($0)).inserted }
+    }
+
+    private static func semanticKey(_ result: LoupeAccessibilityQueryResult) -> String {
+        [result.role ?? "", result.testID ?? "", result.text ?? ""]
+            .map(lengthPrefixed)
+            .joined()
+    }
+
+    private static func exactKey(_ result: LoupeAccessibilityQueryResult) -> String {
+        let frame = result.frame.map { "\($0.x),\($0.y),\($0.width),\($0.height)" } ?? "nil"
+        let point = result.activationPoint.map { "\($0.x),\($0.y)" } ?? "nil"
+        return semanticKey(result) + lengthPrefixed(frame) + lengthPrefixed(point)
+    }
+
+    private static func lengthPrefixed(_ value: String) -> String {
+        "\(value.utf8.count):\(value)"
+    }
+}
+
+package enum ActionTargetAliasText {
+    package static func render(_ cache: ActionTargetAliasCache) -> String {
+        var lines = ["App: \(cache.bundleIdentifier)", ""]
+        lines.append(contentsOf: cache.targets.map { target in
+            let role = nonEmpty(target.role) ?? "element"
+            let text = escaped(nonEmpty(target.text) ?? "")
+            return "#\(target.index) \(role) \"\(text)\""
+        })
+        return lines.joined(separator: "\n")
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private static func escaped(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\t", with: "\\t")
+    }
+}
+
+package struct ActionTargetAliasCacheStore {
+    package var url: URL
+
+    package init(url: URL = Self.defaultURL()) {
+        self.url = url
+    }
+
+    package static func defaultURL() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".loupe", isDirectory: true)
+            .appendingPathComponent("act-targets", isDirectory: true)
+            .appendingPathComponent("current.json")
+    }
+
+    package func store(_ cache: ActionTargetAliasCache) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(cache).write(to: url, options: .atomic)
+    }
+
+    package func load() throws -> ActionTargetAliasCache {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw CLIError("No saved action targets. Run `loupe act targets` and use a quoted alias such as `loupe act tap '#1'`")
+        }
+        do {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            return try decoder.decode(ActionTargetAliasCache.self, from: Data(contentsOf: url))
+        } catch {
+            throw CLIError("Saved action targets are unreadable. Rerun `loupe act targets`")
+        }
+    }
+
+    package func consume(cacheID: String) throws {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return
+        }
+        let current = try load()
+        guard current.cacheID == cacheID else {
+            return
+        }
+        try FileManager.default.removeItem(at: url)
+    }
+}

--- a/Tests/LoupeCLIModelTests/RuntimeActionModelsTests.swift
+++ b/Tests/LoupeCLIModelTests/RuntimeActionModelsTests.swift
@@ -4,6 +4,241 @@ import Testing
 @testable import LoupeCLIModel
 
 struct RuntimeActionModelsTests {
+    @Test func tapParsesQuotedNumericActionTargetAlias() throws {
+        let options = try ActionOptions(
+            command: "tap",
+            arguments: ["#2", "--udid", "SIM-1"]
+        )
+
+        #expect(options.targetAlias == 2)
+        #expect(options.selector == nil)
+        #expect(options.point == nil)
+        #expect(options.udidWasExplicit)
+    }
+
+    @Test func tapAliasIsStrictAndCannotBeMixedWithAnotherTarget() {
+        #expect(throws: CLIError.self) {
+            _ = try ActionOptions(command: "tap", arguments: ["#0"])
+        }
+        #expect(throws: CLIError.self) {
+            _ = try ActionOptions(command: "tap", arguments: ["#01"])
+        }
+        #expect(throws: CLIError.self) {
+            _ = try ActionOptions(command: "tap", arguments: ["#1x"])
+        }
+        #expect(throws: CLIError.self) {
+            _ = try ActionOptions(command: "tap", arguments: ["#1", "--test-id", "checkout.pay"])
+        }
+        #expect(throws: CLIError.self) {
+            _ = try ActionOptions(command: "tap", arguments: ["#1", "--x", "20", "--y", "30"])
+        }
+    }
+
+    @Test func actionTargetPlannerFiltersOrdersAndConservativelyDeduplicates() throws {
+        let screen = LoupeScreen(size: LoupeSize(width: 400, height: 800), scale: 3)
+        let snapshot = LoupeSnapshot(
+            id: "snapshot",
+            capturedAt: Date(timeIntervalSince1970: 0),
+            screen: screen,
+            rootRefs: ["a", "b", "dup", "synthetic", "backing"],
+            nodes: [
+                "a": viewNode(ref: "a"),
+                "b": viewNode(ref: "b"),
+                "dup": viewNode(ref: "dup"),
+                "synthetic": viewNode(
+                    ref: "synthetic",
+                    custom: ["observationBackend": .string("registered-probes")]
+                ),
+                "backing": viewNode(ref: "backing"),
+            ]
+        )
+        let tree = LoupeAccessibilityTree(
+            snapshotID: "ax-snapshot",
+            screen: screen,
+            rootRefs: [],
+            nodes: [
+                "ax-b": axNode(ref: "ax-b", sourceRef: "b", text: "Second", frame: LoupeRect(x: 20, y: 200, width: 80, height: 44)),
+                "ax-a": axNode(ref: "ax-a", sourceRef: "a", text: "First", frame: LoupeRect(x: 20, y: 100, width: 80, height: 44)),
+                "ax-a-duplicate": axNode(ref: "ax-a-duplicate", sourceRef: "dup", text: "First", frame: LoupeRect(x: 20, y: 100, width: 80, height: 44)),
+                "ax-hidden": axNode(ref: "ax-hidden", sourceRef: "hidden", text: "Hidden", frame: LoupeRect(x: 20, y: 10, width: 80, height: 44), visible: false),
+                "ax-disabled": axNode(ref: "ax-disabled", sourceRef: "disabled", text: "Disabled", frame: LoupeRect(x: 20, y: 20, width: 80, height: 44), enabled: false),
+                "ax-static": axNode(ref: "ax-static", sourceRef: "static", text: "Static", frame: LoupeRect(x: 20, y: 30, width: 80, height: 44), interactive: false),
+                "ax-offscreen": axNode(ref: "ax-offscreen", sourceRef: "offscreen", text: "Offscreen", frame: LoupeRect(x: 450, y: 40, width: 80, height: 44)),
+                "ax-synthetic": axNode(ref: "ax-synthetic", sourceRef: "synthetic", text: "Open", testID: "open", frame: LoupeRect(x: 20, y: 300, width: 80, height: 44)),
+                "ax-backing": axNode(ref: "ax-backing", sourceRef: "backing", text: "Open", testID: "open", frame: LoupeRect(x: 220, y: 300, width: 80, height: 44)),
+            ]
+        )
+        let identity = LoupeRuntimeIdentity(
+            launchID: "launch-1",
+            deviceIdentifier: "SIM-1",
+            bundleIdentifier: "com.example.checkout",
+            processIdentifier: 42
+        )
+
+        let cache = ActionTargetAliasPlanner.makeCache(
+            snapshot: snapshot,
+            accessibilityTree: tree,
+            runtimeIdentity: identity,
+            bundleIdentifier: "com.example.checkout",
+            host: URL(string: "http://127.0.0.1:8765")!,
+            cacheID: "cache-1",
+            capturedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(cache.targets.map(\.index) == [1, 2, 3])
+        #expect(cache.targets.map(\.text) == ["First", "Second", "Open"])
+        #expect(cache.targets.last?.sourceRef == "backing")
+        #expect(cache.targets[0].point == LoupePoint(x: 60, y: 122))
+        #expect(cache.totalTargetCount == 3)
+    }
+
+    @Test func actionTargetTextIsCompactAndEscapesLabels() {
+        let cache = aliasCache(
+            targets: [
+                ActionTargetAliasEntry(
+                    index: 1,
+                    ref: "ax-1",
+                    sourceRef: "n1",
+                    role: "button",
+                    text: "Pay \"now\"\nplease",
+                    testID: "checkout.pay",
+                    frame: LoupeRect(x: 10, y: 20, width: 44, height: 44),
+                    activationPoint: nil,
+                    point: LoupePoint(x: 32, y: 42),
+                    isVisible: true,
+                    isEnabled: true,
+                    isInteractive: true
+                ),
+            ]
+        )
+
+        #expect(
+            ActionTargetAliasText.render(cache)
+                == "App: com.example.checkout\n\n#1 button \"Pay \\\"now\\\"\\nplease\""
+        )
+        #expect(!ActionTargetAliasText.render(cache).contains("checkout.pay"))
+        #expect(!ActionTargetAliasText.render(cache).contains("frame"))
+    }
+
+    @Test func actionTargetCacheRejectsNonActionableCachedEntry() {
+        let invalid = ActionTargetAliasEntry(
+            index: 1,
+            ref: "ax-1",
+            sourceRef: "n1",
+            role: "button",
+            text: "Pay",
+            testID: nil,
+            frame: nil,
+            activationPoint: nil,
+            point: LoupePoint(x: 900, y: 900),
+            isVisible: true,
+            isEnabled: true,
+            isInteractive: true
+        )
+
+        #expect(throws: CLIError.self) {
+            _ = try aliasCache(targets: [invalid]).target(at: 1)
+        }
+    }
+
+    @Test func actionTargetCacheRejectsRuntimeMismatches() throws {
+        let cache = aliasCache(targets: [])
+        let matching = LoupeRuntimeIdentity(
+            launchID: "launch-1",
+            deviceIdentifier: "SIM-1",
+            bundleIdentifier: "com.example.checkout",
+            processIdentifier: 42
+        )
+        try cache.validate(host: URL(string: "http://127.0.0.1:8765/")!, runtimeIdentity: matching)
+
+        var earlierLaunch = matching
+        earlierLaunch.launchID = "launch-2"
+        #expect(throws: CLIError.self) {
+            try cache.validate(host: URL(string: "http://127.0.0.1:8765")!, runtimeIdentity: earlierLaunch)
+        }
+        var otherDevice = matching
+        otherDevice.deviceIdentifier = "SIM-2"
+        #expect(throws: CLIError.self) {
+            try cache.validate(host: URL(string: "http://127.0.0.1:8765")!, runtimeIdentity: otherDevice)
+        }
+        var otherApp = matching
+        otherApp.bundleIdentifier = "com.example.other"
+        #expect(throws: CLIError.self) {
+            try cache.validate(host: URL(string: "http://127.0.0.1:8765")!, runtimeIdentity: otherApp)
+        }
+        #expect(throws: CLIError.self) {
+            try cache.validate(host: URL(string: "http://127.0.0.1:9999")!, runtimeIdentity: matching)
+        }
+        var futureSchema = cache
+        futureSchema.schemaVersion += 1
+        #expect(throws: CLIError.self) {
+            try futureSchema.validate(host: URL(string: "http://127.0.0.1:8765")!, runtimeIdentity: matching)
+        }
+    }
+
+    @Test func actionTargetPlannerBoundsLightweightOutput() {
+        let screen = LoupeScreen(size: LoupeSize(width: 400, height: 800), scale: 3)
+        var viewNodes: [String: LoupeNode] = [:]
+        var accessibilityNodes: [String: LoupeAccessibilityNode] = [:]
+        for index in 0..<105 {
+            let sourceRef = "n\(index)"
+            viewNodes[sourceRef] = viewNode(ref: sourceRef)
+            accessibilityNodes["ax-\(sourceRef)"] = axNode(
+                ref: "ax-\(sourceRef)",
+                sourceRef: sourceRef,
+                text: "Target \(index)",
+                frame: LoupeRect(x: Double(index % 10) * 30, y: Double(index / 10) * 50, width: 20, height: 20)
+            )
+        }
+        let snapshot = LoupeSnapshot(
+            id: "snapshot",
+            capturedAt: Date(timeIntervalSince1970: 0),
+            screen: screen,
+            rootRefs: Array(viewNodes.keys),
+            nodes: viewNodes
+        )
+        let tree = LoupeAccessibilityTree(
+            snapshotID: "ax-snapshot",
+            screen: screen,
+            rootRefs: Array(accessibilityNodes.keys),
+            nodes: accessibilityNodes
+        )
+        let cache = ActionTargetAliasPlanner.makeCache(
+            snapshot: snapshot,
+            accessibilityTree: tree,
+            runtimeIdentity: LoupeRuntimeIdentity(
+                launchID: "launch-1",
+                deviceIdentifier: "SIM-1",
+                bundleIdentifier: "com.example.checkout",
+                processIdentifier: 42
+            ),
+            bundleIdentifier: "com.example.checkout",
+            host: URL(string: "http://127.0.0.1:8765")!
+        )
+
+        #expect(cache.totalTargetCount == 105)
+        #expect(cache.targets.count == ActionTargetAliasPlanner.maximumTargetCount)
+        #expect(cache.targets.last?.index == ActionTargetAliasPlanner.maximumTargetCount)
+    }
+
+    @Test func actionTargetCacheIsAtomicallyReplacedAndConsumedOnce() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("loupe-action-target-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ActionTargetAliasCacheStore(url: directory.appendingPathComponent("current.json"))
+        let first = aliasCache(cacheID: "first", targets: [])
+        let second = aliasCache(cacheID: "second", targets: [])
+
+        try store.store(first)
+        try store.store(second)
+        #expect(try store.load().cacheID == "second")
+
+        try store.consume(cacheID: "first")
+        #expect(try store.load().cacheID == "second")
+        try store.consume(cacheID: "second")
+        #expect(!FileManager.default.fileExists(atPath: store.url.path))
+    }
+
     @Test func coordinateSwipeKeepsPointsAndRequiresRuntimeScreenWhenNoExplicitSize() throws {
         let options = try ActionOptions(
             command: "swipe",
@@ -205,5 +440,62 @@ struct RuntimeActionModelsTests {
         #expect(ActionTraceText.recordable(command: "type", text: "hunter2") == "<redacted>")
         #expect(ActionTraceText.recordable(command: "type", text: nil) == nil)
         #expect(ActionTraceText.recordable(command: "swipe", text: "metadata") == "metadata")
+    }
+
+    private func aliasCache(
+        cacheID: String = "cache-1",
+        targets: [ActionTargetAliasEntry]
+    ) -> ActionTargetAliasCache {
+        ActionTargetAliasCache(
+            cacheID: cacheID,
+            capturedAt: Date(timeIntervalSince1970: 0),
+            launchID: "launch-1",
+            deviceIdentifier: "SIM-1",
+            bundleIdentifier: "com.example.checkout",
+            host: "http://127.0.0.1:8765",
+            snapshotID: "snapshot-1",
+            screen: LoupeScreen(size: LoupeSize(width: 400, height: 800), scale: 3),
+            targets: targets
+        )
+    }
+
+    private func axNode(
+        ref: String,
+        sourceRef: String,
+        text: String,
+        testID: String? = nil,
+        frame: LoupeRect,
+        visible: Bool = true,
+        enabled: Bool = true,
+        interactive: Bool = true
+    ) -> LoupeAccessibilityNode {
+        LoupeAccessibilityNode(
+            ref: ref,
+            sourceRef: sourceRef,
+            role: "button",
+            label: text,
+            testID: testID,
+            frame: frame,
+            isVisible: visible,
+            isEnabled: enabled,
+            isInteractive: interactive
+        )
+    }
+
+    private func viewNode(
+        ref: String,
+        custom: [String: LoupeMetadataValue] = [:]
+    ) -> LoupeNode {
+        LoupeNode(
+            ref: ref,
+            parentRef: nil,
+            kind: .view,
+            typeName: "UIView",
+            frame: LoupeRect(x: 0, y: 0, width: 1, height: 1),
+            isVisible: true,
+            isEnabled: true,
+            isInteractive: true,
+            custom: custom
+        )
     }
 }

--- a/Tests/LoupeCLITests/ActionBackendTests.swift
+++ b/Tests/LoupeCLITests/ActionBackendTests.swift
@@ -1,4 +1,5 @@
 @testable import LoupeCLI
+@testable import LoupeCLIModel
 import Foundation
 import LoupeCore
 import Testing
@@ -110,6 +111,39 @@ struct ActionBackendTests {
         let filtered = LoupeCLI.preferPlatformBackedActionMatches(matches, snapshot: snapshot)
 
         #expect(filtered.map(\.sourceRef) == ["backing"])
+    }
+
+    @Test func cachedAliasTargetKeepsAccessibilityTraceProvenance() throws {
+        let entry = ActionTargetAliasEntry(
+            index: 2,
+            ref: "ax-n42",
+            sourceRef: "n42",
+            role: "button",
+            text: "Pay",
+            testID: "checkout.pay",
+            frame: LoupeRect(x: 20, y: 100, width: 80, height: 44),
+            activationPoint: LoupePoint(x: 60, y: 122),
+            point: LoupePoint(x: 60, y: 122),
+            isVisible: true,
+            isEnabled: true,
+            isInteractive: true
+        )
+        let cache = ActionTargetAliasCache(
+            launchID: "launch-1",
+            deviceIdentifier: "SIM-1",
+            bundleIdentifier: "com.example.checkout",
+            host: "http://127.0.0.1:8765",
+            snapshotID: "snapshot-1",
+            screen: LoupeScreen(size: LoupeSize(width: 400, height: 800), scale: 3),
+            targets: [entry]
+        )
+
+        let target = try LoupeCLI.actionTarget(alias: 2, cache: cache)
+
+        #expect(target.source.description == "accessibility:ax-n42:source:n42")
+        #expect(target.match?.trace.tree == "accessibility")
+        #expect(target.match?.trace.testID == "checkout.pay")
+        #expect(target.point == LoupePoint(x: 60, y: 122))
     }
 
     private func openImmersiveDuplicateProbeSnapshot() -> LoupeSnapshot {

--- a/Tests/LoupeCLITests/CLIHelpTests.swift
+++ b/Tests/LoupeCLITests/CLIHelpTests.swift
@@ -62,7 +62,8 @@ import Testing
             "ui apply-design-suggestions": "Usage: loupe ui apply-design-suggestions <compare-design.json> [--host <url>] [--snapshot <snapshot.json>] [--output-dir <dir>] [--max <n>] [--properties <list>] [--dry-run]",
             "ui set": "Usage: loupe ui set (--test-id <id> | --ref <ref> | --role <role> | --text <text>) <property> <value> [--host <url>] [--udid <sim>] [--bundle-id <id>] [--snapshot <snapshot.json>] [--include-hidden] [--output <path>]",
             "act": "Usage: loupe act <subcommand>",
-            "act tap": "Usage: loupe act tap (--test-id <id> | --ref <view-or-ax-ref> | --x <n> --y <n>) [--udid <sim>] [--host <url>] [--backend native|runtime|auto] [--snapshot <snapshot.json>] [--trace-dir <path>] [--expect-visible <testID>] [--timeout <seconds>]",
+            "act targets": "Usage: loupe act targets [--udid <sim>] [--host <url>] [--timeout <seconds>]",
+            "act tap": "Usage: loupe act tap ('#N' | --test-id <id> | --ref <view-or-ax-ref> | --x <n> --y <n>) [--udid <sim>] [--host <url>] [--backend native|runtime|auto] [--snapshot <snapshot.json>] [--trace-dir <path>] [--expect-visible <testID>] [--timeout <seconds>]",
             "act swipe": "Usage: loupe act swipe --from x,y --to x,y [--udid <sim>] [--host <url>] [--duration <seconds>] [--no-verify-scroll] [--trace-dir <path>] [--timeout <seconds>]",
             "act drag": "Usage: loupe act drag --from x,y --to x,y [--udid <sim>] [--host <url>] [--duration <seconds>] [--trace-dir <path>] [--timeout <seconds>]",
             "act type": "Usage: loupe act type <text> [--udid <sim>] [--host <url>] [--trace-dir <path>] [--timeout <seconds>]",
@@ -144,6 +145,7 @@ import Testing
             "ui compare-design",
             "ui apply-design-suggestions",
             "act",
+            "act targets",
             "act tap",
             "act swipe",
             "act drag",
@@ -183,6 +185,17 @@ import Testing
 
         #expect(help.contains("dev.loupe.log"))
         #expect(help.contains("NotificationCenter"))
+    }
+
+    @Test func actionTargetHelpQuotesHashAlias() throws {
+        let act = try #require(LoupeCLI.commandUsage("act"))
+        let targets = try #require(LoupeCLI.commandUsage("act targets"))
+        let tap = try #require(LoupeCLI.commandUsage("act tap"))
+
+        #expect(act.contains("targets"))
+        #expect(targets.contains("loupe act targets"))
+        #expect(tap.contains("loupe act tap '#2'"))
+        #expect(tap.contains("'#N'"))
     }
 
     @Test func ambiguousCompatibilityCommandsAreNotPublic() {

--- a/skills/loupe/SKILL.md
+++ b/skills/loupe/SKILL.md
@@ -30,6 +30,8 @@ runtimes through the in-process server.
   next decision.
 - Prefer accessibility for discovery/action intent; prefer the view tree for
   layout, style, mutations, and visual diagnostics.
+- For screen movement, use `act targets` then `act tap '#N'`. For view
+  analysis, use `ui report`.
 - Command success alone is not proof. Verify with fresh reports, traces,
   screenshots, hit-tests, logs, defaults, or effective state.
 
@@ -62,9 +64,10 @@ runtimes through the in-process server.
 
 1. Identify the runtime mode and host. Prefer the host printed by `app launch`;
    `app current` can be stale.
-2. Capture `ui report` and keep `snapshot.json`.
-3. Discover with text/role/accessibility, then switch to `testID` or a current
-   ref. Inspect with `ui node` before acting.
+2. Use `act targets` then `act tap '#N'` for lightweight screen movement. The
+   quoted alias is one-shot; list targets again before the next alias action.
+3. Use `ui report` for view analysis. Keep `snapshot.json`, then query or
+   inspect only the relevant nodes.
 4. For design checks, capture one report, review the screenshot and audit
    summary, then run `ui compare-design` when a design fixture exists.
 5. Keep each design iteration bounded: report, screenshot/audit judgment,

--- a/skills/loupe/references/actions-and-mutations.md
+++ b/skills/loupe/references/actions-and-mutations.md
@@ -6,6 +6,8 @@ source reflection.
 ## Action Shapes
 
 ```bash
+$LOUPE act targets --host <host>
+$LOUPE act tap '#2' --host <host>
 $LOUPE act tap --host <host> --snapshot <snapshot.json> --ref n21 --udid <sim-udid> --trace-dir <trace-dir>
 $LOUPE act tap --host <host> --x 201 --y 274 --width 438 --height 954 --udid <sim-udid> --trace-dir <trace-dir>
 $LOUPE act swipe --host <host> --from 219,760 --to 219,190 --udid <sim-udid> --trace-dir <trace-dir>
@@ -16,6 +18,11 @@ $LOUPE debug trace summary <trace-dir>
 ```
 
 Use one fresh trace directory per attempt.
+
+Use `act targets` for movement and `ui report` for view analysis. `#N` aliases
+come from visible, enabled, interactive accessibility nodes. Quote the alias;
+it is consumed after a successful dispatch, so list targets again before the
+next alias action.
 
 ## Proof Rules
 


### PR DESCRIPTION
## What changed

This adds a lightweight movement path built from the current accessibility tree.

`loupe act targets` prints copyable `#N role "text"` entries for visible, enabled, interactive targets. `loupe act tap '#N'` uses the selected target through a runtime-scoped one-shot cache that validates the host, app launch, device, and bundle before dispatch.

The default output stays compact and omits internal test IDs, frames, and points. Full view analysis remains under `loupe ui report`, and the bundled Loupe skill now routes agents accordingly.

Aliases are immediate one-shot handles, not durable selectors across navigation.

## Checked

- `swift test`
- `Examples/LoupeExample/run-native-scenarios.sh`
- `scripts/verify-agent-work.sh`