### PR TITLE
Clarify act targets runtime selection

### DIFF
--- a/Examples/LoupeExample/run-native-scenarios.sh
+++ b/Examples/LoupeExample/run-native-scenarios.sh
@@ -271,7 +271,7 @@ echo "case: accessibility action targets are copyable and one-shot"
 TARGETS_PATH="/tmp/loupe-native-action-targets.txt"
 TARGETS_RETRY_OUT="/tmp/loupe-native-action-targets-retry.out"
 TARGETS_RETRY_ERR="/tmp/loupe-native-action-targets-retry.err"
-.build/debug/loupe act targets --host "$HOST" --udid "$DEVICE" > "$TARGETS_PATH"
+.build/debug/loupe act targets --udid "$DEVICE" > "$TARGETS_PATH"
 grep -Eq '^App: .+$' "$TARGETS_PATH"
 if grep -Eq 'testID=|frame=|point=' "$TARGETS_PATH"; then
   echo "error: default action targets leaked internal fields" >&2

--- a/Sources/LoupeCLI/ActTargets.swift
+++ b/Sources/LoupeCLI/ActTargets.swift
@@ -3,14 +3,12 @@ import LoupeCLIModel
 import LoupeCore
 
 struct ActTargetsOptions {
-    var host: URL
-    var hostWasExplicit: Bool
+    var host: URL?
     var udid: String?
     var timeout: TimeInterval
 
     init(_ arguments: [String]) throws {
-        host = URL(string: "http://127.0.0.1:8765")!
-        hostWasExplicit = false
+        host = nil
         var udid: String?
         var timeout: TimeInterval = 5
         var index = 0
@@ -24,7 +22,6 @@ struct ActTargetsOptions {
                     throw CLIError("Invalid --host URL: \(raw)")
                 }
                 host = url
-                hostWasExplicit = true
             case "--udid", "--device":
                 udid = try Self.value(after: argument, in: arguments, index: &index)
             case "--timeout":
@@ -58,7 +55,6 @@ extension LoupeCLI {
         let options = try ActTargetsOptions(arguments)
         let host = try await resolvedRuntimeHost(
             requestedHost: options.host,
-            hostWasExplicit: options.hostWasExplicit,
             udid: options.udid
         )
         let runtimeState = try await fetchRuntimeState(host: host, timeout: options.timeout)

--- a/Sources/LoupeCLI/RuntimeSelection.swift
+++ b/Sources/LoupeCLI/RuntimeSelection.swift
@@ -106,6 +106,21 @@ extension LoupeCLI {
     }
 
     static func resolvedRuntimeHost(
+        requestedHost: URL?,
+        udid: String?
+    ) async throws -> URL {
+        if let requestedHost {
+            return requestedHost
+        }
+
+        return try await resolvedRuntimeHost(
+            requestedHost: URL(string: "http://127.0.0.1:8765")!,
+            hostWasExplicit: false,
+            udid: udid
+        )
+    }
+
+    static func resolvedRuntimeHost(
         requestedHost: URL,
         hostWasExplicit: Bool,
         udid: String?,

--- a/Tests/LoupeCLITests/ActTargetsOptionsTests.swift
+++ b/Tests/LoupeCLITests/ActTargetsOptionsTests.swift
@@ -1,0 +1,30 @@
+@testable import LoupeCLI
+import Foundation
+import Testing
+
+@Suite struct ActTargetsOptionsTests {
+    @Test func omittedHostRemainsUnspecified() throws {
+        let options = try ActTargetsOptions([])
+
+        #expect(options.host == nil)
+    }
+
+    @Test func parsesExplicitHost() throws {
+        let options = try ActTargetsOptions([
+            "--host", "http://127.0.0.1:30632",
+        ])
+
+        #expect(options.host?.absoluteString == "http://127.0.0.1:30632")
+    }
+
+    @Test func optionalResolverPreservesExplicitHost() async throws {
+        let explicitHost = try #require(URL(string: "http://127.0.0.1:30632"))
+
+        let resolvedHost = try await LoupeCLI.resolvedRuntimeHost(
+            requestedHost: explicitHost,
+            udid: nil
+        )
+
+        #expect(resolvedHost == explicitHost)
+    }
+}


### PR DESCRIPTION
## What changed

`act targets` now represents an omitted `--host` as an actual missing value instead of the concrete SDK fallback URL.

Runtime selection still preserves explicit hosts and otherwise follows the existing UDID record, current runtime, and SDK fallback order. The change stays scoped to `act targets`; other CLI option types are unchanged.

The native scenario now exercises `act targets --udid <device>` against a dynamically assigned runtime port.

## Checked

- `swift test` (289 tests, 42 suites)
- `Examples/LoupeExample/run-native-scenarios.sh`
- `scripts/verify-agent-work.sh`

Closes #10