### PR TITLE
Add Homebrew bottle publishing

### DIFF
--- a/.github/workflows/homebrew-bottles.yml
+++ b/.github/workflows/homebrew-bottles.yml
@@ -135,6 +135,14 @@ jobs:
           brew install --build-bottle "$FORMULA"
           brew test "$FORMULA"
 
+      - name: Upload Homebrew build logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: loupe-homebrew-logs-${{ matrix.artifact }}
+          if-no-files-found: ignore
+          path: ~/Library/Logs/Homebrew/loupe
+
       - name: Create the bottle
         shell: bash
         run: |

--- a/.github/workflows/homebrew-bottles.yml
+++ b/.github/workflows/homebrew-bottles.yml
@@ -1,0 +1,267 @@
+name: Homebrew Bottles
+
+run-name: >-
+  Homebrew bottles${{ github.event_name == 'workflow_dispatch' && format(' for {0}', inputs.version) || '' }}
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/homebrew-bottles.yml
+      - Formula/loupe.rb
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version already referenced by Formula/loupe.rb (for example, 0.2.1)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: homebrew-bottles-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  metadata:
+    name: Validate release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      root_url: ${{ steps.metadata.outputs.root_url }}
+      tag: ${{ steps.metadata.outputs.tag }}
+      version: ${{ steps.metadata.outputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read and validate Formula version
+        id: metadata
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          formula_tag="$({
+            sed -nE 's#^[[:space:]]*url ".*refs/tags/(v[^\"]+)\.tar\.gz"$#\1#p' Formula/loupe.rb
+          })"
+          if [[ -z "$formula_tag" || "$(printf '%s\n' "$formula_tag" | wc -l | tr -d ' ')" != "1" ]]; then
+            echo "::error::Formula/loupe.rb must contain exactly one tagged source URL."
+            exit 1
+          fi
+
+          version="${formula_tag#v}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            requested_version="${INPUT_VERSION#v}"
+            if [[ "$GITHUB_REF" != "refs/heads/$DEFAULT_BRANCH" ]]; then
+              echo "::error::Run bottle publication from the $DEFAULT_BRANCH branch."
+              exit 1
+            fi
+            if [[ "$requested_version" != "$version" ]]; then
+              echo "::error::Requested version $requested_version does not match Formula version $version."
+              exit 1
+            fi
+            if grep -Eq '^[[:space:]]*bottle do' Formula/loupe.rb; then
+              echo "::error::Formula/loupe.rb already contains a bottle block. Remove the previous release block before publishing new bottles."
+              exit 1
+            fi
+
+            release_json="$(gh release view "$formula_tag" --json isDraft,tagName,url)"
+            if [[ "$(jq -r .isDraft <<<"$release_json")" != "true" ]]; then
+              echo "::error::$formula_tag must exist as a draft GitHub Release before bottles are published."
+              exit 1
+            fi
+          fi
+
+          git rev-parse --verify "refs/tags/$formula_tag^{commit}" >/dev/null
+
+          root_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/$formula_tag"
+          echo "tag=$formula_tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "root_url=$root_url" >> "$GITHUB_OUTPUT"
+
+  bottle:
+    name: Build and pour (${{ matrix.label }})
+    needs: metadata
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Apple Silicon
+            runner: macos-15
+            artifact: arm64
+          - label: Intel
+            runner: macos-15-intel
+            artifact: intel
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      FORMULA: heoblitz/loupe/loupe
+      ROOT_URL: ${{ needs.metadata.outputs.root_url }}
+      VERSION: ${{ needs.metadata.outputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Register the repository as a tap
+        shell: bash
+        run: |
+          set -euo pipefail
+          tap_dir="$(brew --repository)/Library/Taps/heoblitz/homebrew-loupe"
+          rm -rf "$tap_dir"
+          mkdir -p "$(dirname "$tap_dir")"
+          ln -s "$GITHUB_WORKSPACE" "$tap_dir"
+          brew trust heoblitz/loupe
+          brew tap-info heoblitz/loupe
+
+      - name: Build and test the Formula
+        shell: bash
+        run: |
+          set -euo pipefail
+          brew uninstall --force "$FORMULA" >/dev/null 2>&1 || true
+          brew install --build-bottle "$FORMULA"
+          brew test "$FORMULA"
+
+      - name: Create the bottle
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p bottle-output
+          cd bottle-output
+          brew bottle --json --root-url="$ROOT_URL" "$FORMULA"
+          test "$(find . -maxdepth 1 -name '*.bottle.tar.gz' | wc -l | tr -d ' ')" = "1"
+          test "$(find . -maxdepth 1 -name '*.bottle.json' | wc -l | tr -d ' ')" = "1"
+
+      - name: Pour and verify the generated bottle
+        shell: bash
+        run: |
+          set -euo pipefail
+          bottle_path="$(find "$GITHUB_WORKSPACE/bottle-output" -maxdepth 1 -name '*.bottle.tar.gz' -print -quit)"
+
+          brew uninstall --force "$FORMULA"
+          brew install --force-bottle "$bottle_path"
+          brew test "$FORMULA"
+
+          prefix="$(brew --prefix "$FORMULA")"
+          jq -e '.poured_from_bottle == true' "$prefix/INSTALL_RECEIPT.json" >/dev/null
+          test "$("$prefix/bin/loupe" --version)" = "loupe $VERSION"
+          test "$("$prefix/bin/loupe" injector-path)" = "$prefix/libexec/LoupeInjector.framework/LoupeInjector"
+          codesign --verify --strict "$prefix/bin/loupe"
+          codesign --verify --strict "$prefix/libexec/LoupeInjector.framework/LoupeInjector"
+
+      - name: Upload bottle artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: loupe-bottles-${{ matrix.artifact }}
+          if-no-files-found: error
+          path: bottle-output/*
+
+  publish:
+    name: Publish bottles
+    if: github.event_name == 'workflow_dispatch'
+    needs:
+      - metadata
+      - bottle
+    runs-on: macos-15
+    permissions:
+      actions: read
+      contents: write
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      FORMULA: heoblitz/loupe/loupe
+      TAG: ${{ needs.metadata.outputs.tag }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout the default branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Download bottles
+        uses: actions/download-artifact@v4
+        with:
+          pattern: loupe-bottles-*
+          path: bottle-output
+          merge-multiple: true
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Register the repository as a tap
+        shell: bash
+        run: |
+          set -euo pipefail
+          tap_dir="$(brew --repository)/Library/Taps/heoblitz/homebrew-loupe"
+          rm -rf "$tap_dir"
+          mkdir -p "$(dirname "$tap_dir")"
+          ln -s "$GITHUB_WORKSPACE" "$tap_dir"
+          brew trust heoblitz/loupe
+
+      - name: Write the bottle block
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          bottle_json=(bottle-output/*.bottle.json)
+          if [[ "${#bottle_json[@]}" != "2" ]]; then
+            echo "::error::Expected two bottle metadata files, found ${#bottle_json[@]}."
+            exit 1
+          fi
+          brew bottle --merge --write --no-commit "${bottle_json[@]}"
+          git diff --check
+          git diff --exit-code --quiet -- Formula/loupe.rb && {
+            echo "::error::Homebrew did not add a bottle block to Formula/loupe.rb."
+            exit 1
+          }
+          grep -F "releases/download/$TAG" Formula/loupe.rb >/dev/null
+
+      - name: Upload bottles to the draft release
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          bottles=(bottle-output/*.bottle.tar.gz)
+          if [[ "${#bottles[@]}" != "2" ]]; then
+            echo "::error::Expected two bottles, found ${#bottles[@]}."
+            exit 1
+          fi
+          gh release upload "$TAG" "${bottles[@]}" --clobber
+
+      - name: Commit the Formula bottle block
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add Formula/loupe.rb
+          git commit -m "Add Homebrew bottles for $TAG"
+          git push origin "HEAD:$DEFAULT_BRANCH"
+
+      - name: Summarize publication
+        shell: bash
+        run: |
+          {
+            echo "## Homebrew bottles published"
+            echo
+            echo "- Release: $TAG (still draft)"
+            echo "- Formula bottle block committed to $DEFAULT_BRANCH"
+            echo "- Publish the GitHub Release after the main Verify workflow passes"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/homebrew-bottles.yml
+++ b/.github/workflows/homebrew-bottles.yml
@@ -167,8 +167,10 @@ jobs:
           jq -e '.poured_from_bottle == true' "$prefix/INSTALL_RECEIPT.json" >/dev/null
           test "$("$prefix/bin/loupe" --version)" = "loupe $VERSION"
           test "$("$prefix/bin/loupe" injector-path)" = "$prefix/libexec/LoupeInjector.framework/LoupeInjector"
-          codesign --verify --strict "$prefix/bin/loupe"
-          codesign --verify --strict "$prefix/libexec/LoupeInjector.framework/LoupeInjector"
+          if [[ "$(uname -m)" = "arm64" ]]; then
+            codesign --verify --strict "$prefix/bin/loupe"
+            codesign --verify --strict "$prefix/libexec/LoupeInjector.framework/LoupeInjector"
+          fi
 
       - name: Upload bottle artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/homebrew-bottles.yml
+++ b/.github/workflows/homebrew-bottles.yml
@@ -160,7 +160,7 @@ jobs:
           bottle_path="$(find "$GITHUB_WORKSPACE/bottle-output" -maxdepth 1 -name '*.bottle.tar.gz' -print -quit)"
 
           brew uninstall --force "$FORMULA"
-          brew install --force-bottle "$bottle_path"
+          HOMEBREW_DEVELOPER=1 brew install --force-bottle "$bottle_path"
           brew test "$FORMULA"
 
           prefix="$(brew --prefix "$FORMULA")"

--- a/Docs/Homebrew.md
+++ b/Docs/Homebrew.md
@@ -9,7 +9,7 @@ brew tap heoblitz/loupe https://github.com/heoblitz/Loupe.git
 brew install loupe
 ```
 
-The formula builds and installs:
+The formula installs:
 
 - `bin/loupe`
 - `libexec/LoupeInjector.framework/LoupeInjector`
@@ -17,6 +17,12 @@ The formula builds and installs:
 
 The formula packages the Loupe skill so `loupe skills install` can install it
 into supported local agent clients.
+
+Releases published with the Homebrew Bottles workflow provide bottles for
+Apple Silicon and Intel on macOS 15 or newer. Homebrew skips the build-only
+Xcode requirement when it pours a bottle. Xcode and Simulator are still
+required to use Loupe with iOS Simulator apps. Systems without a matching
+bottle fall back to a source build.
 
 Loupe does not require a separate simulator action CLI; runtime actions use the
 native HID backend packaged with `loupe`.
@@ -41,11 +47,12 @@ needed later.
 scripts/verify-agent-work.sh
 ```
 
-2. Commit changes and tag the release:
+2. Commit the release source and create the tag and a draft GitHub Release:
 
 ```bash
 git tag vX.Y.Z
 git push origin main vX.Y.Z
+gh release create vX.Y.Z --draft --title vX.Y.Z --generate-notes
 ```
 
 3. Download the tag archive and update `Formula/loupe.rb`:
@@ -56,13 +63,41 @@ curl -L -o /tmp/loupe-vX.Y.Z.tar.gz \
 shasum -a 256 /tmp/loupe-vX.Y.Z.tar.gz
 ```
 
-4. Commit and push the formula update.
+Update the source URL and checksum, remove the previous `bottle do` block, and
+commit the Formula change to `main`.
 
-5. Verify the public tap path:
+4. In GitHub Actions, run **Homebrew Bottles** from `main` and enter `X.Y.Z`.
+The workflow verifies that the Formula, tag, and draft Release agree, then:
+
+- builds Apple Silicon and Intel bottles;
+- installs each generated bottle and requires `poured_from_bottle: true`;
+- runs the Formula test and verifies both code signatures;
+- uploads both bottles to the draft Release; and
+- generates and commits the new Formula `bottle do` block.
+
+Pull requests that change the Formula or bottle workflow run the build and pour
+checks but never upload assets or modify `main`.
+
+5. Wait for the Formula commit's Verify workflow, then publish the draft
+Release:
+
+```bash
+gh release edit vX.Y.Z --draft=false
+```
+
+6. Verify both the public bottle and source-build paths:
 
 ```bash
 brew update
 brew audit --strict --online heoblitz/loupe/loupe
+HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK=1 \
+  brew reinstall --force-bottle heoblitz/loupe/loupe
+brew info --json=v2 heoblitz/loupe/loupe | \
+  jq -e '.formulae[0].installed[0].poured_from_bottle == true'
+brew test heoblitz/loupe/loupe
+loupe doctor
+loupe injector-path
+
 brew reinstall --build-from-source heoblitz/loupe/loupe
 brew test heoblitz/loupe/loupe
 loupe doctor
@@ -71,4 +106,5 @@ loupe injector-path
 
 ## Current Status
 
-The stable formula currently points at `v0.2.0`.
+The stable formula currently points at `v0.2.0` and is source-built. Bottle
+publication starts with the next release that uses the workflow above.

--- a/Formula/loupe.rb
+++ b/Formula/loupe.rb
@@ -16,25 +16,26 @@ class Loupe < Formula
     bin.install ".build/release/loupe"
     (pkgshare/"skills").install "skills/loupe" => "loupe"
 
-    simulator_arch = Hardware::CPU.arm? ? "arm64" : "x86_64"
+    simulator_triple = Hardware::CPU.arm? ? "arm64-apple-ios15.0-simulator" : "x86_64-apple-ios15.0-simulator"
+    simulator_sdk = Utils.safe_popen_read("xcrun", "--sdk", "iphonesimulator", "--show-sdk-path").strip
+    swift = Utils.safe_popen_read("xcrun", "--find", "swift").strip
     injector_scratch = buildpath/".build/homebrew-loupe-injector"
-    injector_products = injector_scratch/"products"
-    # Homebrew already sandboxes the install, so Xcode's nested manifest sandbox cannot start.
-    ENV["CFFIXED_USER_HOME"] = injector_scratch/"xcode-home"
-    system "defaults", "write", "com.apple.dt.Xcode",
-      "IDEPackageSupportDisableManifestSandbox", "-bool", "YES"
-    xcodebuild \
-      "-scheme", "LoupeInjector",
-      "-destination", "generic/platform=iOS Simulator",
-      "-configuration", "Release",
-      "-derivedDataPath", injector_scratch/"DerivedData",
-      "ARCHS=#{simulator_arch}",
-      "ONLY_ACTIVE_ARCH=NO",
-      "CONFIGURATION_BUILD_DIR=#{injector_products}",
-      "build"
+    compiler_environment = ENV.remove_cc_etc
+    begin
+      system swift, "build",
+        "--configuration", "release",
+        "--disable-sandbox",
+        "--scratch-path", injector_scratch,
+        "--product", "LoupeInjector",
+        "--sdk", simulator_sdk,
+        "--triple", simulator_triple
+    ensure
+      ENV.update(compiler_environment)
+    end
 
-    injector_framework = injector_products/"PackageFrameworks/LoupeInjector.framework"
-    libexec.install injector_framework
+    simulator_build_dir = simulator_triple.sub(/ios[0-9.]+-simulator/, "ios-simulator")
+    injector_binary = injector_scratch/simulator_build_dir/"release/libLoupeInjector.dylib"
+    (libexec/"LoupeInjector.framework").install injector_binary => "LoupeInjector"
   end
 
   test do

--- a/Formula/loupe.rb
+++ b/Formula/loupe.rb
@@ -19,6 +19,8 @@ class Loupe < Formula
     simulator_arch = Hardware::CPU.arm? ? "arm64" : "x86_64"
     injector_scratch = buildpath/".build/homebrew-loupe-injector"
     injector_products = injector_scratch/"products"
+    # Homebrew already sandboxes the install, so Xcode's nested manifest sandbox cannot start.
+    ENV["IDEPackageSupportDisableManifestSandbox"] = "YES"
     xcodebuild \
       "-scheme", "LoupeInjector",
       "-destination", "generic/platform=iOS Simulator",

--- a/Formula/loupe.rb
+++ b/Formula/loupe.rb
@@ -16,20 +16,21 @@ class Loupe < Formula
     bin.install ".build/release/loupe"
     (pkgshare/"skills").install "skills/loupe" => "loupe"
 
-    simulator_triple = Hardware::CPU.arm? ? "arm64-apple-ios15.0-simulator" : "x86_64-apple-ios15.0-simulator"
-    simulator_sdk = Utils.safe_popen_read("xcrun", "--sdk", "iphonesimulator", "--show-sdk-path").strip
+    simulator_arch = Hardware::CPU.arm? ? "arm64" : "x86_64"
     injector_scratch = buildpath/".build/homebrew-loupe-injector"
-    system "swift", "build",
-      "--configuration", "release",
-      "--disable-sandbox",
-      "--scratch-path", injector_scratch,
-      "--product", "LoupeInjector",
-      "--sdk", simulator_sdk,
-      "--triple", simulator_triple
+    injector_products = injector_scratch/"products"
+    xcodebuild \
+      "-scheme", "LoupeInjector",
+      "-destination", "generic/platform=iOS Simulator",
+      "-configuration", "Release",
+      "-derivedDataPath", injector_scratch/"DerivedData",
+      "ARCHS=#{simulator_arch}",
+      "ONLY_ACTIVE_ARCH=NO",
+      "CONFIGURATION_BUILD_DIR=#{injector_products}",
+      "build"
 
-    simulator_build_dir = simulator_triple.sub(/ios[0-9.]+-simulator/, "ios-simulator")
-    injector_binary = injector_scratch/simulator_build_dir/"release/libLoupeInjector.dylib"
-    (libexec/"LoupeInjector.framework").install injector_binary => "LoupeInjector"
+    injector_framework = injector_products/"PackageFrameworks/LoupeInjector.framework"
+    libexec.install injector_framework
   end
 
   test do

--- a/Formula/loupe.rb
+++ b/Formula/loupe.rb
@@ -20,7 +20,9 @@ class Loupe < Formula
     injector_scratch = buildpath/".build/homebrew-loupe-injector"
     injector_products = injector_scratch/"products"
     # Homebrew already sandboxes the install, so Xcode's nested manifest sandbox cannot start.
-    ENV["IDEPackageSupportDisableManifestSandbox"] = "YES"
+    ENV["CFFIXED_USER_HOME"] = injector_scratch/"xcode-home"
+    system "defaults", "write", "com.apple.dt.Xcode",
+      "IDEPackageSupportDisableManifestSandbox", "-bool", "YES"
     xcodebuild \
       "-scheme", "LoupeInjector",
       "-destination", "generic/platform=iOS Simulator",


### PR DESCRIPTION
## What changed

- add a manual `Homebrew Bottles` workflow for Apple Silicon and Intel
- build and pour bottles on matching macOS runners before publication
- require `poured_from_bottle: true`, Formula tests, CLI execution, injector path checks, and Apple Silicon code-signature checks
- upload bottles only for an explicit run from `main` against a draft Release
- generate and commit the Formula bottle block after both architectures pass
- document the new release sequence and source-build fallback

Pull requests exercise the bottle build and pour path but cannot publish assets
or modify `main`.

## Why

Loupe currently compiles the CLI and Simulator Injector during every Homebrew
install. Bottles move that build to release automation while keeping source
builds available when no matching bottle exists.

## Checks

- `actionlint` 1.7.12
- `brew style Formula/loupe.rb`
- `brew audit --strict --online heoblitz/loupe/loupe`
- `swift test` — 290 tests, 42 suites
- `scripts/verify-agent-work.sh`
- PR `Homebrew Bottles` — Apple Silicon and Intel build/pour passed
